### PR TITLE
Fixing create_address_manager_user python 3 compatibility

### DIFF
--- a/Community/create_address_manager_user/create_address_manager_user_page.py
+++ b/Community/create_address_manager_user/create_address_manager_user_page.py
@@ -29,8 +29,13 @@ from bluecat.user import User
 
 
 def module_path():
-    encoding = sys.getfilesystemencoding()
-    return os.path.dirname(os.path.abspath(unicode(__file__, encoding)))
+    """
+    Get module path.
+
+    :return:
+    """
+    return os.path.dirname(os.path.abspath(str(__file__)))
+
 
 #This is a check to see if the user exists
 def doesUserExsist(userName):


### PR DESCRIPTION
This community workflow is not compatible with python 3 (newest versions of gateway). The following error message was observed:
```
[2018-12-28T21:08:57Z][PID:18][gateway] INFO: [192.168.245.1] User retrieving API endpoint: /create_address_manager_user/create_address_manager_user_endpoint
[2018-12-28T21:08:57Z][PID:18][gateway] ERROR: EXCEPTION THROWN: name 'unicode' is not defined
[2018-12-28T21:08:57Z][PID:18][gateway] INFO: Returning [302 FOUND] from endpoint: /create_address_manager_user/create_address_manager_user_endpoint
[2018-12-28T21:08:57Z][PID:18][gateway] DEBUG: Falling back to home url for user
```

Adding support by removing the unicode method (python2 based) from the module_path function inside its page file.