### PR TITLE
Update user permissions workflow fix

### DIFF
--- a/Community/update_user_permissions/update_user_permissions_page.py
+++ b/Community/update_user_permissions/update_user_permissions_page.py
@@ -30,8 +30,11 @@ from .util_custom import get_udf_portal_groups
 access_type_not_update = 'GUI_AND_API'
 
 def module_path():
-    encoding = sys.getfilesystemencoding()
-    return os.path.dirname(os.path.abspath(unicode(__file__, encoding)))
+    """
+    Get module path.
+    :return:
+    """
+    return os.path.dirname(os.path.abspath(str(__file__)))
 
 # The workflow name must be the first part of any endpoints defined in this file.
 # If you break this rule, you will trip up on other people's endpoint names and

--- a/Community/update_user_permissions/util_custom.py
+++ b/Community/update_user_permissions/util_custom.py
@@ -39,7 +39,7 @@ def get_udf_portal_groups():
     udfs = g.user.get_api()._api_client.service.getUserDefinedFields('User', "False")
     group_values = []
     for udf in udfs.item:
-        if udf['name'] == 'PortalGroup':
+        if udf['name'] == 'PortalGroup' and udf['predefinedValues']:
             for group_value in udf['predefinedValues'].split('|'):
                 if group_value != '':
                     group_values.append((group_value, group_value))


### PR DESCRIPTION
Fixing 2 errors:

1 - This community workflow will break in python 3 (newest versions of gateway) due to the unicode function into module_path.

2 - Avoiding split a NoneType object when the user doesn't have a gateway group assigned to an address manager user group.

```
[2018-12-28T21:32:11Z][PID:18][gateway] INFO: [192.168.245.1] User retrieving API endpoint: /update_user_permissions/update_user_permissions_endpoint
[2018-12-28T21:32:11Z][PID:18][gateway] ERROR: EXCEPTION THROWN: 'NoneType' object has no attribute 'split'
```
