### PR TITLE
 add_mac_address / fix incorrect mac name value

### DIFF
--- a/Community/add_mac_address/add_mac_address_page.py
+++ b/Community/add_mac_address/add_mac_address_page.py
@@ -76,7 +76,7 @@ def add_mac_address_add_mac_address_page_form():
 
         # Add MAC address
         try:
-            mac_address = configuration.add_mac_address(form.mac_address.data, form.mac_address_name, mac_pool)
+            mac_address = configuration.add_mac_address(form.mac_address.data, form.mac_address_name.data, mac_pool)
         except BAMException as e:
             g.user.logger.error('%s' % e, msg_type=g.user.logger.EXCEPTION)
             if 'Duplicate of another item' in util.safe_str(e):


### PR DESCRIPTION
in  add_mac_address workflow, the macaddress name was pushed with a wrong variable into BAM
instead of the value in the from field, the whole form field was pushed