### PR TITLE
Adding Dual Stack Host workflow

### DIFF
--- a/Community/add_dual_stack_host/README.md
+++ b/Community/add_dual_stack_host/README.md
@@ -1,0 +1,26 @@
+<!-- Copyright 2020 BlueCat Networks. All rights reserved. -->
+
+Copyright 2020 BlueCat Networks (USA) Inc. and its affiliates
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+Project Title: **Add Dual Stack Host** <br/>
+By: **Erik Pineiro epineiro@bluecatnetworks.com** <br/>
+Date: **15-09-2020** <br/>
+BlueCat Gateway Version: **20.6.1** <br/>
+Description: **Fill in the form in order. Configuration, 
+View, and Zone are prepopulated dropdowns. Hostname takes a string.
+IPv4 only accepts addresses within networks that already exist within
+BAM. Fill in the IPv6 address field exactly.**<br/>
+**The add device radio button will add a device attached to the created host record.**

--- a/Community/add_dual_stack_host/__init__.py
+++ b/Community/add_dual_stack_host/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2020 BlueCat Networks. All rights reserved.
+# -*- coding: utf-8 -*-
+
+type = 'ui'
+sub_pages = [
+    {
+        'name'        : 'add_dual_stack_host_page',
+        'title'       : u'Add Dual Stack Host',
+        'endpoint'    : 'add_dual_stack_host/add_dual_stack_host_endpoint',
+        'description' : u'For adding a dual stack host i.e. IPv4 and IPv6'
+    },
+]

--- a/Community/add_dual_stack_host/add_dual_stack_host_form.py
+++ b/Community/add_dual_stack_host/add_dual_stack_host_form.py
@@ -1,0 +1,119 @@
+# Copyright 2020 BlueCat Networks. All rights reserved.
+"""
+Workflow form template
+"""
+import datetime
+
+from wtforms import StringField, PasswordField, FileField
+from wtforms import BooleanField, DateTimeField, SubmitField
+from wtforms.validators import DataRequired, Email, MacAddress, URL
+from bluecat.wtform_extensions import GatewayForm
+from bluecat.wtform_fields import Configuration, CustomStringField, IP4Address, View, Zone, CustomBooleanField, \
+    PlainHTML
+from .add_dual_stack_host_wtform_fields import IP6Address
+
+
+def filter_reserved(res):
+    """
+    Filter reserved IP.
+    :param res:
+    :return:
+    """
+    try:
+        if res['data']['state'] == 'RESERVED':
+            res['status'] = 'FAIL'
+            res['message'] = 'Host records cannot be added if ip address is reserved.'
+        return res
+    except (TypeError, KeyError):
+        return res
+
+
+class GenericFormTemplate(GatewayForm):
+    """
+    Generic form Template
+
+    Note:
+        When updating the form, remember to make the corresponding changes to the workflow pages
+    """
+    workflow_name = 'add_dual_stack_host'
+    workflow_permission = 'add_dual_stack_host_page'
+    configuration = Configuration(
+        workflow_name=workflow_name,
+        permissions=workflow_permission,
+        label='Configuration',
+        required=True,
+        coerce=int,
+        validators=[],
+        is_disabled_on_start=False,
+        on_complete=['call_view'],
+        enable_dependencies={'on_complete': ['view']},
+        disable_dependencies={'on_change': ['view']},
+        clear_dependencies={'on_change': ['view']},
+        clear_below_on_change=False
+    )
+
+    view = View(
+        workflow_name=workflow_name,
+        permissions=workflow_permission,
+        label='View',
+        required=True,
+        one_off=True,
+        on_complete=['call_zone'],
+        clear_below_on_change=False,
+        enable_dependencies={'on_complete': ['zone']},
+        disable_dependencies={'on_change': ['zone']},
+        clear_dependencies={'on_change': ['zone']},
+        should_cascade_disable_on_change=True,
+        should_cascade_clear_on_change=True
+    )
+
+    zone = Zone(
+        workflow_name=workflow_name,
+        permissions=workflow_permission,
+        label='Zone',
+        required=True,
+        clear_below_on_change=False,
+        enable_dependencies={'on_complete': ['hostname', 'ip_address', 'ip6_address']},
+        disable_dependencies={'on_change': ['hostname', 'ip_address', 'ip6_address']},
+        clear_dependencies={'on_change': ['hostname', 'ip_address', 'ip6_address']},
+        should_cascade_disable_on_change=True,
+        should_cascade_clear_on_change=True
+    )
+
+    hostname = CustomStringField(
+        label='Hostname',
+        required=True
+    )
+
+    ip_address = IP4Address(
+        workflow_name=workflow_name,
+        permissions=workflow_permission,
+        label='IPv4 Address',
+        required=True,
+        inputs={'configuration': 'configuration', 'address': 'ip_address'},
+        result_decorator=filter_reserved,
+        enable_dependencies={'on_complete': ['submit', 'ip6_address']},
+        disable_dependencies={'on_change': ['submit', 'ip6_address']},
+        should_cascade_disable_on_change=True
+    )
+
+    ip6_address = IP6Address(
+        workflow_name=workflow_name,
+        permissions=workflow_permission,
+        label='IPv6 Address',
+        required=True,
+        inputs={'configuration': 'configuration', 'ip6_address': 'ip6_address'},
+        result_decorator=None,
+        disable_dependencies={'on_change': ['hostname', 'submit', 'ip_address']},
+        enable_on_complete=['submit']
+    )
+
+    add_device = CustomBooleanField(
+        label='Add Device',
+        is_disabled_on_start=False
+    )
+
+    submit = SubmitField(label='Submit')
+
+    # Button with JS to clear the form
+    clear_button = PlainHTML('<button type="button" onclick="clearForm();" class="clearForm">Clear Form</button>')

--- a/Community/add_dual_stack_host/add_dual_stack_host_logic.py
+++ b/Community/add_dual_stack_host/add_dual_stack_host_logic.py
@@ -1,0 +1,99 @@
+# Copyright 2020 BlueCat Networks. All rights reserved.
+from flask import g, request, jsonify
+
+from main_app import app
+from bluecat import route, util
+from bluecat.entity import Entity
+import bluecat_portal.config as config
+from bluecat.util import rest_exception_catcher
+from bluecat.util import rest_workflow_permission_required
+from bluecat.util import is_valid_ipv6_address
+from bluecat.api_exception import PortalException
+from bluecat.server_endpoints import empty_decorator, get_result_template
+import logging
+logging.basicConfig(level=logging.DEBUG)
+
+SUCCESS = 'SUCCESS'
+FAIL = 'FAIL'
+
+def get_ip6_address_endpoint(workflow_name, element_id, permissions, result_decorator=None):
+    """
+    Generate an endpoint for retrieving IP6 Address data. Accepts the following keys in the posted form:
+    configuration, address.
+
+    Where:
+        configuration - The ID of the configuration containing the IPv6 Address.
+
+        address - The IP of the IPv6 Address.
+
+    Returns:
+        IP6 object with status, name and MAC address properties if it is a valid address within a network.
+
+    :param workflow_name: The name of the workflow that is using this endpoint.
+    :param element_id: The ID of the form field using this endpoint.
+    :param permissions: What workflow permissions the user needs to access this endpoint.
+    :param result_decorator: Function to add custom manipulations to a result set.
+    :return: The generated endpoint unique to get_ip6_address_endpoint.
+    """
+
+    endpoint = 'get_ip6_address'
+    function_endpoint = '%sget_ip6_address' % workflow_name
+    view_function = app.view_functions.get(function_endpoint)
+    if view_function is not None:
+        return endpoint
+
+    if not result_decorator:
+        result_decorator = empty_decorator
+
+
+    @route(app, '/%s/%s' % (workflow_name, endpoint), methods=['GET', 'POST'])
+    @rest_workflow_permission_required(permissions)
+    @rest_exception_catcher
+    # pylint: disable=unused-variable
+    def get_ip6_address():
+        """
+        Exposed endpoint for retrieving an IP6 address.
+        :return: All data in the BAM about the IP6 address.
+        """
+        if request.method == 'POST':
+            configuration_id = request.form['configuration']
+            ip6_address = request.form['ip6_address']
+            return jsonify(result_decorator(get_address_data(configuration_id, ip6_address)))
+
+    return endpoint
+
+
+def get_address_data(configuration_id, ip6_address):
+    """
+    Get the BAM data for a given ip6_address in the given configuration.
+
+    :param configuration_id: The ID of the configuration in which the ip6_address resides.
+    :param ip6_address: The IP address in string form.
+    :return: The IP address data in JSON, using result template format.
+    """
+
+    # Regular expression to match IPv6 format
+    result = get_result_template()
+    if not is_valid_ipv6_address(ip6_address):
+        result['message'] = 'IP address is invalid.'
+        result['status'] = FAIL
+        return result
+
+    # Retrieve the configuration object
+    configuration = g.user.get_api().get_entity_by_id(configuration_id)
+
+    # Check if IP address exists within a network. Fail if not.
+    try:
+        configuration.get_ip_ranged_by_ip(Entity.IP6Network, ip6_address)
+        result['message'] = 'IPv6 Address is available'
+        result['status'] = SUCCESS
+        result['data'] = {
+            'state': None,
+            'mac_address': None,
+            'name': None
+        }
+        return result
+    except PortalException:
+        result['message'] = 'IP address is not in a network or network does not exist'
+        result['status'] = FAIL
+        return result

--- a/Community/add_dual_stack_host/add_dual_stack_host_page.py
+++ b/Community/add_dual_stack_host/add_dual_stack_host_page.py
@@ -1,0 +1,103 @@
+# Copyright 2020 BlueCat Networks. All rights reserved.
+import os
+import sys
+import codecs
+
+from flask import url_for, redirect, render_template, flash, g, request
+
+from bluecat import route, util
+import config.default_config as config
+from main_app import app
+from .add_dual_stack_host_form import GenericFormTemplate
+
+
+def module_path():
+    encoding = sys.getfilesystemencoding()
+    return os.path.dirname(os.path.abspath(__file__))
+
+
+# The workflow name must be the first part of any endpoints defined in this file.
+# If you break this rule, you will trip up on other people's endpoint names and
+# chaos will ensue.
+@route(app, '/add_dual_stack_host/add_dual_stack_host_endpoint')
+@util.workflow_permission_required('add_dual_stack_host_page')
+@util.exception_catcher
+@util.ui_secure_endpoint
+def add_dual_stack_host_add_dual_stack_host_page():
+    form = GenericFormTemplate()
+    # Remove this line if your workflow does not need to select a configuration
+    form.configuration.choices = util.get_configurations(default_val=True)
+    return render_template(
+        'add_dual_stack_host_page.html',
+        form=form,
+        text=util.get_text(module_path(), config.language),
+        options=g.user.get_options(),
+    )
+
+
+@route(app, '/add_dual_stack_host/form', methods=['POST'])
+@util.workflow_permission_required('add_dual_stack_host_page')
+@util.exception_catcher
+@util.ui_secure_endpoint
+def add_dual_stack_host_add_dual_stack_host_page_form():
+    form = GenericFormTemplate()
+    # Remove this line if your workflow does not need to select a configuration
+    form.configuration.choices = util.get_configurations(default_val=True)
+
+    address_list = []
+    if form.validate_on_submit():
+        try:
+            # Retrieve form attributes
+            configuration = g.user.get_api().get_entity_by_id(form.configuration.data)
+            view = configuration.get_view(request.form['view'])
+            absolute_name = form.hostname.data + '.' + request.form['zone']
+            ip4_address = request.form['ip_address']
+            ip6_address = request.form['ip6_address']
+
+            # Add IP4 and IP6 addresses to address list
+            address_list.append(ip4_address)
+            address_list.append(ip6_address)
+            add_device = request.form.get('add_device') # Must use 'get' otherwise returns a 400 error on False
+
+            # Add Host Record
+            host_record = view.add_host_record(absolute_name, address_list)
+
+            # Optionally Add Device
+            if add_device:
+                device_id = g.user.get_api()._api_client.service.addDevice(
+                    configurationId=form.configuration.data, deviceSubtypeId='0', deviceTypeId='0',
+                    ip4Addresses=ip4_address, ip6Addresses=ip6_address, name=form.hostname.data
+                )
+                device_name = g.user.get_api().get_entity_by_id(device_id).get_name()
+                g.user.logger.info('Success - Device ' + device_name +
+                                ' added with Object ID: ' + util.safe_str(device_id))
+                flash('Success - Device ' + device_name +
+                    ' added with Object ID: ' + util.safe_str(device_id), 'succeed')
+
+            # Put form processing code here
+            g.user.logger.info('Success - Host (A & AAAA) Record ' + host_record.get_property('absoluteName') +
+                               ' added with Object ID: ' + util.safe_str(host_record.get_id()))
+
+            flash('Success - Host (A & AAAA) Record ' + host_record.get_property('absoluteName') +
+                  ' added with Object ID: ' +
+                  util.safe_str(host_record.get_id()), 'succeed')
+
+
+            return redirect(url_for('add_dual_stack_hostadd_dual_stack_host_add_dual_stack_host_page'))
+        except Exception as e:
+            flash(util.safe_str(e))
+            # Log error and render workflow page
+            g.user.logger.warning('%s' % util.safe_str(e), msg_type=g.user.logger.EXCEPTION)
+            return render_template('add_dual_stack_host_page.html',
+                                   form=form,
+                                   text=util.get_text(module_path(), config.language),
+                                   options=g.user.get_options())
+
+    else:
+        g.user.logger.info('Form data was not valid.')
+        return render_template(
+            'add_dual_stack_host_page.html',
+            form=form,
+            text=util.get_text(module_path(), config.language),
+            options=g.user.get_options(),
+        )

--- a/Community/add_dual_stack_host/add_dual_stack_host_wtform_fields.py
+++ b/Community/add_dual_stack_host/add_dual_stack_host_wtform_fields.py
@@ -1,0 +1,29 @@
+# Copyright 2020 BlueCat Networks. All rights reserved.
+from bluecat.wtform_fields import SimpleAutocompleteField, ValidatingStringField
+from .add_dual_stack_host_logic import get_ip6_address_endpoint
+# Import Javascript Helpers
+from bluecat.ui_components.wtform_widgets import SuperSelect
+from bluecat.wtform_fields.custom_string_field import CustomStringField
+
+class IP6Address(ValidatingStringField):
+    """
+    StringField for inputting IPv6 addresses with client-side validation
+    and auto-checks that the network exists.
+
+    :param label: HTML label for the generated field.
+    :param validators: WTForm validators for the field run on the server side.
+    :param result_decorator: Function to manipulate result set instead of a server-side call.
+    :param kwargs: Other keyword arguments for WTForms Fields.
+
+    """
+    def __init__(self, label='IPv6 Address', validators=None, result_decorator=None, **kwargs):
+        """ Pass parameters to ValidatingStringField for initialization.
+        """
+        super(IP6Address, self).__init__(
+            label,
+            validators,
+            client_side_validator='valid_ip6_address',
+            server_side_method=get_ip6_address_endpoint,
+            result_decorator=result_decorator,
+            **kwargs
+        )

--- a/Community/add_dual_stack_host/css/add_dual_stack_host_page.css
+++ b/Community/add_dual_stack_host/css/add_dual_stack_host_page.css
@@ -1,0 +1,14 @@
+/* Copyright 2020 BlueCat Networks. All rights reserved. */
+/* Custom styles for your page go in here. */
+.clearForm {
+background-color: #757575;
+color: black;
+}
+.clearForm:hover {
+background-color: #8a8a8a;
+color: white;
+}
+.clearForm button, input[type="submit"], input[type="button"] {
+display: inline-block;
+margin-right: 30px;
+}

--- a/Community/add_dual_stack_host/js/add_dual_stack_host_page.js
+++ b/Community/add_dual_stack_host/js/add_dual_stack_host_page.js
@@ -1,0 +1,51 @@
+// Copyright 2020 BlueCat Networks. All rights reserved.
+$(document).ready(function() {
+
+});
+
+function valid_ip6_address(ip)
+{
+    return /^(?:(?:(?:(?:(?:(?:(?:[0-9a-fA-F]{1,4})):){6})(?:(?:(?:(?:(?:[0-9a-fA-F]{1,4})):(?:(?:[0-9a-fA-F]{1,4})))|(?:(?:(?:(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9]))\.){3}(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9])))))))|(?:(?:::(?:(?:(?:[0-9a-fA-F]{1,4})):){5})(?:(?:(?:(?:(?:[0-9a-fA-F]{1,4})):(?:(?:[0-9a-fA-F]{1,4})))|(?:(?:(?:(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9]))\.){3}(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9])))))))|(?:(?:(?:(?:(?:[0-9a-fA-F]{1,4})))?::(?:(?:(?:[0-9a-fA-F]{1,4})):){4})(?:(?:(?:(?:(?:[0-9a-fA-F]{1,4})):(?:(?:[0-9a-fA-F]{1,4})))|(?:(?:(?:(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9]))\.){3}(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9])))))))|(?:(?:(?:(?:(?:(?:[0-9a-fA-F]{1,4})):){0,1}(?:(?:[0-9a-fA-F]{1,4})))?::(?:(?:(?:[0-9a-fA-F]{1,4})):){3})(?:(?:(?:(?:(?:[0-9a-fA-F]{1,4})):(?:(?:[0-9a-fA-F]{1,4})))|(?:(?:(?:(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9]))\.){3}(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9])))))))|(?:(?:(?:(?:(?:(?:[0-9a-fA-F]{1,4})):){0,2}(?:(?:[0-9a-fA-F]{1,4})))?::(?:(?:(?:[0-9a-fA-F]{1,4})):){2})(?:(?:(?:(?:(?:[0-9a-fA-F]{1,4})):(?:(?:[0-9a-fA-F]{1,4})))|(?:(?:(?:(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9]))\.){3}(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9])))))))|(?:(?:(?:(?:(?:(?:[0-9a-fA-F]{1,4})):){0,3}(?:(?:[0-9a-fA-F]{1,4})))?::(?:(?:[0-9a-fA-F]{1,4})):)(?:(?:(?:(?:(?:[0-9a-fA-F]{1,4})):(?:(?:[0-9a-fA-F]{1,4})))|(?:(?:(?:(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9]))\.){3}(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9])))))))|(?:(?:(?:(?:(?:(?:[0-9a-fA-F]{1,4})):){0,4}(?:(?:[0-9a-fA-F]{1,4})))?::)(?:(?:(?:(?:(?:[0-9a-fA-F]{1,4})):(?:(?:[0-9a-fA-F]{1,4})))|(?:(?:(?:(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9]))\.){3}(?:(?:25[0-5]|(?:[1-9]|1[0-9]|2[0-4])?[0-9])))))))|(?:(?:(?:(?:(?:(?:[0-9a-fA-F]{1,4})):){0,5}(?:(?:[0-9a-fA-F]{1,4})))?::)(?:(?:[0-9a-fA-F]{1,4})))|(?:(?:(?:(?:(?:(?:[0-9a-fA-F]{1,4})):){0,6}(?:(?:[0-9a-fA-F]{1,4})))?::))))$/.test(ip)
+}
+
+function validator_ip6_address() {
+    $("#ip6_address").attr("disabled", false);
+    var input = $("#ip6_address").val();
+    clear_ip6_address_message(input);
+
+    if (valid_ip6_address($("#ip6_address").val())) {
+        var data = {
+            "configuration": $("#configuration").val(),
+            "ip6_address": $("#ip6_address").val()
+        };
+        $("body").addClass("waiting");
+
+        $.post("/add_dual_stack_host/get_ip6_address", data, function(response) {
+            $("body").removeClass("waiting");
+            if (input != $("#ip6_address").val()) {
+                return;
+            }
+            if (response.status == "FAIL" || response.data.length == 0) {
+                $("#ip6_address").bootstrapError();
+            } else {
+                $("#ip6_address").bootstrapSuccess();
+
+                var dependent_functions = ['enable_mac_address', 'enable_submit'];
+                var dependent_ids = ['mac_address', 'submit'];
+                enable_disable_ui_components(dependent_ids, dependent_functions, false);
+
+            }
+        }).fail(function() {
+            $("body").removeClass("waiting");
+        }).always(function(returnData) {
+            populate_ip6_address_message(returnData);
+        });
+
+    } else {
+        $("#ip6_address").bootstrapError();
+    }
+}
+
+function clearForm() {
+    document.getElementById("add_dual_stack_host_page_form").reset();
+}

--- a/Community/add_dual_stack_host/templates/add_dual_stack_host_page.html
+++ b/Community/add_dual_stack_host/templates/add_dual_stack_host_page.html
@@ -1,0 +1,28 @@
+<!-- Copyright 2020 BlueCat Networks. All rights reserved. -->
+
+{% extends "base.html" %}
+
+{% block css %}
+<link rel="stylesheet" href="css/add_dual_stack_host_page.css?version={{ g.version | urlencode }}">
+{% endblock %}
+
+{% block title %}
+{{ text['title'] }}
+{% endblock %}
+
+{% block heading %}
+{{ text['title'] }}
+{% endblock %}
+
+{% block custom %}
+
+    <p>{{ text['info'] }}</p>
+    <!--Your page's HTML goes here.-->
+    {% from "form_helper.html" import render_form %}
+    {{ render_form(form, action=url_for('add_dual_stack_hostadd_dual_stack_host_add_dual_stack_host_page_form'), id="add_dual_stack_host_page_form") }}
+
+{% endblock %}
+
+{% block scripts %}
+<script src="js/add_dual_stack_host_page.js?version={{ g.version | urlencode }}"></script>
+{% endblock %}

--- a/Community/add_dual_stack_host/text/en.txt
+++ b/Community/add_dual_stack_host/text/en.txt
@@ -1,0 +1,2 @@
+title=Add Dual Stack Host
+info=


### PR DESCRIPTION
The purpose of this workflow is to add dual stack hosts to BAM. This works off of the certified Add Host Record workflow but adds an IPv6 address with client side validation to the host record as well. In addition, there is also a radio button to optionally add a device attached to the created host record.