### PR TITLE
Fixed variable 'new_dl' use before declaration

### DIFF
--- a/Edge/Edge Internal Namespace/edge_create_internal_ns/edge_create_internal_ns_page.py
+++ b/Edge/Edge Internal Namespace/edge_create_internal_ns/edge_create_internal_ns_page.py
@@ -50,6 +50,7 @@ def edge_create_internal_ns_edge_create_internal_ns_page_form():
             print("Contacted the Edge")
 
         # Find the domain list ID
+        new_dl = False
         try:
             # Create the Domain List if it doesn't exist
             dl = edge_session.make_new_domain_list(form.domainlist_name.data, form.domainlist_desc.data)


### PR DESCRIPTION
In latest gw the Edge namespace workflow was generating an error related to a variable being referenced before assignment.  Log example:

`[2021-04-14T15:03:42Z][PID:102][gateway] ERROR: EXCEPTION THROWN: local variable 'new_dl' referenced before assignment`

Change is to declare new_dl = False before the if statement that was causing the issue.  Not clear why new version of gw is behaving this way.