### PR TITLE
Update Example workflows for Gateway 23.1.0

### DIFF
--- a/Examples/Alias Record/README.md
+++ b/Examples/Alias Record/README.md
@@ -1,9 +1,9 @@
 # **Example Alias Record Workflows**
 ## Add, Delete, and Update Alias Records
 
-**BlueCat Gateway Version:** 22.11.1 or greater <br/>
-**BAM version:** 9.2.0 or greater <br/>
+**BlueCat Gateway Version:** 23.1.0 or greater <br/>
+**BAM version:** 9.3.0 or greater <br/>
 **Dependencies:** Configuration, View, Zone, Block, Network, and Host Record previously created in Address Manager <br/>
 **Description/Example Usage:** The Alias (CNAME) Record requires a name, linked record zone, and a linked Host Record. Using the Alias Record workflow, you can add, delete, or update Alias (CNAME) Records in a zone. This workflow is ideal for self-service customers using the BlueCat Gateway user interface and for IPAM or DNS administrators to help reduce the repetition usually associated with daily record management.
 
-©2020-2022 BlueCat Networks (USA) Inc. and its affiliates (collectively 'BlueCat'). All rights reserved.
+©2020-2023 BlueCat Networks (USA) Inc. and its affiliates (collectively 'BlueCat'). All rights reserved.

--- a/Examples/Alias Record/__init__.py
+++ b/Examples/Alias Record/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,6 @@
 # limitations under the License.
 #
 # By: BlueCat Networks
-# Date: 2022-11-30
-# Gateway Version: 22.11.1
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
 # Description: Example Gateway workflow

--- a/Examples/Alias Record/add_alias_record/__init__.py
+++ b/Examples/Alias Record/add_alias_record/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 # By: BlueCat Networks
-# Date: 2022-11-30
-# Gateway Version: 22.11.1
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
 # Description: Example Gateway workflow
 
 # pylint: disable=redefined-builtin,missing-docstring

--- a/Examples/Alias Record/add_alias_record/add_alias_record_form.py
+++ b/Examples/Alias Record/add_alias_record/add_alias_record_form.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 # By: BlueCat Networks
-# Date: 2022-11-30
-# Gateway Version: 22.11.1
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
 # Description: Example Gateway workflow
 
 """

--- a/Examples/Alias Record/add_alias_record/add_alias_record_page.py
+++ b/Examples/Alias Record/add_alias_record/add_alias_record_page.py
@@ -58,7 +58,6 @@ def add_alias_record_add_alias_record_page():
         "add_alias_record_page.html",
         form=form,
         text=util.get_text(module_path(), config.language),
-        options=g.user.get_options(),
     )
 
 
@@ -110,7 +109,6 @@ def add_alias_record_add_alias_record_page_form():
                 "add_alias_record_page.html",
                 form=form,
                 text=util.get_text(module_path(), config.language),
-                options=g.user.get_options(),
             )
     else:
         g.user.logger.info("Form data was not valid.")
@@ -118,5 +116,4 @@ def add_alias_record_add_alias_record_page_form():
             "add_alias_record_page.html",
             form=form,
             text=util.get_text(module_path(), config.language),
-            options=g.user.get_options(),
         )

--- a/Examples/Alias Record/add_alias_record/add_alias_record_page.py
+++ b/Examples/Alias Record/add_alias_record/add_alias_record_page.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 # By: BlueCat Networks
-# Date: 2022-11-30
-# Gateway Version: 22.11.1
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
 # Description: Example Gateway workflow
 
 """

--- a/Examples/Alias Record/add_alias_record/css/add_alias_record_page.css
+++ b/Examples/Alias Record/add_alias_record/css/add_alias_record_page.css
@@ -1,4 +1,4 @@
-/* Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+/* Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 By: BlueCat Networks
-Date: 2022-11-30
-Gateway Version: 22.11.1
+Date: 2023-04-05
+Gateway Version: 23.1.0
 Description: Example Gateway workflow
 */
 

--- a/Examples/Alias Record/add_alias_record/js/add_alias_record_page.js
+++ b/Examples/Alias Record/add_alias_record/js/add_alias_record_page.js
@@ -1,4 +1,4 @@
-// Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+// Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 // limitations under the License.
 //
 // By: BlueCat Networks
-// Date: 2022-11-30
-// Gateway Version: 22.11.1
+// Date: 2023-04-05
+// Gateway Version: 23.1.0
 // Description: Example Gateway workflow
 
 // JavaScript for your page goes in here.

--- a/Examples/Alias Record/add_alias_record/templates/add_alias_record_page.html
+++ b/Examples/Alias Record/add_alias_record/templates/add_alias_record_page.html
@@ -1,4 +1,4 @@
-<!-- Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+<!-- Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 By: BlueCat Networks
-Date: 2022-11-30
-Gateway Version: 22.11.1
+Date: 2023-04-05
+Gateway Version: 23.1.0
 Description: Example Gateway workflow
 -->
 
@@ -33,7 +33,6 @@ Description: Example Gateway workflow
 {% endblock %}
 
 {% block custom %}
-
     <p>{{ text['info'] }}</p>
     {% from "form_helper.html" import render_form %}
     {{ render_form(form, action=url_for('add_alias_recordadd_alias_record_add_alias_record_page_form'), id="add_alias_record_form") }}

--- a/Examples/Alias Record/delete_alias_record/__init__.py
+++ b/Examples/Alias Record/delete_alias_record/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 # By: BlueCat Networks
-# Date: 2022-11-30
-# Gateway Version: 22.11.1
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
 # Description: Example Gateway workflow
 
 # pylint: disable=redefined-builtin,missing-docstring

--- a/Examples/Alias Record/delete_alias_record/css/delete_alias_record_page.css
+++ b/Examples/Alias Record/delete_alias_record/css/delete_alias_record_page.css
@@ -1,4 +1,4 @@
-/* Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+/* Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 By: BlueCat Networks
-Date: 2022-11-30
-Gateway Version: 22.11.1
+Date: 2023-04-05
+Gateway Version: 23.1.0
 Description: Example Gateway workflow
 */
 

--- a/Examples/Alias Record/delete_alias_record/delete_alias_record_form.py
+++ b/Examples/Alias Record/delete_alias_record/delete_alias_record_form.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 # By: BlueCat Networks
-# Date: 2022-11-30
-# Gateway Version: 22.11.1
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
 # Description: Example Gateway workflow
 
 """

--- a/Examples/Alias Record/delete_alias_record/delete_alias_record_page.py
+++ b/Examples/Alias Record/delete_alias_record/delete_alias_record_page.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 # By: BlueCat Networks
-# Date: 2022-11-30
-# Gateway Version: 22.11.1
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
 # Description: Example Gateway workflow
 
 """

--- a/Examples/Alias Record/delete_alias_record/delete_alias_record_page.py
+++ b/Examples/Alias Record/delete_alias_record/delete_alias_record_page.py
@@ -58,7 +58,6 @@ def delete_alias_record_delete_alias_record_page():
         "delete_alias_record_page.html",
         form=form,
         text=util.get_text(module_path(), config.language),
-        options=g.user.get_options(),
     )
 
 
@@ -110,7 +109,6 @@ def delete_alias_record_delete_alias_record_page_form():
                 "delete_alias_record_page.html",
                 form=form,
                 text=util.get_text(module_path(), config.language),
-                options=g.user.get_options(),
             )
     else:
         g.user.logger.info("Form data was not valid.")
@@ -118,5 +116,4 @@ def delete_alias_record_delete_alias_record_page_form():
             "delete_alias_record_page.html",
             form=form,
             text=util.get_text(module_path(), config.language),
-            options=g.user.get_options(),
         )

--- a/Examples/Alias Record/delete_alias_record/js/delete_alias_record_page.js
+++ b/Examples/Alias Record/delete_alias_record/js/delete_alias_record_page.js
@@ -1,4 +1,4 @@
-// Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+// Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 // limitations under the License.
 //
 // By: BlueCat Networks
-// Date: 2022-11-30
-// Gateway Version: 22.11.1
+// Date: 2023-04-05
+// Gateway Version: 23.1.0
 // Description: Example Gateway workflow
 
 // JavaScript for your page goes in here.

--- a/Examples/Alias Record/delete_alias_record/templates/delete_alias_record_page.html
+++ b/Examples/Alias Record/delete_alias_record/templates/delete_alias_record_page.html
@@ -1,4 +1,4 @@
-<!-- Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+<!-- Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 By: BlueCat Networks
-Date: 2022-11-30
-Gateway Version: 22.11.1
+Date: 2023-04-05
+Gateway Version: 23.1.0
 Description: Example Gateway workflow
 -->
 
@@ -33,7 +33,6 @@ Description: Example Gateway workflow
 {% endblock %}
 
 {% block custom %}
-
     <p>{{ text['info'] }}</p>
     {% from "form_helper.html" import render_form %}
     {{ render_form(form, action=url_for('delete_alias_recorddelete_alias_record_delete_alias_record_page_form'), id="delete_alias_record_form") }}

--- a/Examples/Alias Record/update_alias_record/__init__.py
+++ b/Examples/Alias Record/update_alias_record/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 # By: BlueCat Networks
-# Date: 2022-11-30
-# Gateway Version: 22.11.1
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
 # Description: Example Gateway workflow
 
 # pylint: disable=redefined-builtin,missing-docstring

--- a/Examples/Alias Record/update_alias_record/css/update_alias_record_page.css
+++ b/Examples/Alias Record/update_alias_record/css/update_alias_record_page.css
@@ -1,4 +1,4 @@
-/* Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+/* Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 By: BlueCat Networks
-Date: 2022-11-30
-Gateway Version: 22.11.1
+Date: 2023-04-05
+Gateway Version: 23.1.0
 Description: Example Gateway workflow
 */
 

--- a/Examples/Alias Record/update_alias_record/js/update_alias_record_page.js
+++ b/Examples/Alias Record/update_alias_record/js/update_alias_record_page.js
@@ -1,4 +1,4 @@
-// Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+// Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 // limitations under the License.
 //
 // By: BlueCat Networks
-// Date: 2022-11-30
-// Gateway Version: 22.11.1
+// Date: 2023-04-05
+// Gateway Version: 23.1.0
 // Description: Example Gateway workflow
 
 // JavaScript for your page goes in here.

--- a/Examples/Alias Record/update_alias_record/templates/update_alias_record_page.html
+++ b/Examples/Alias Record/update_alias_record/templates/update_alias_record_page.html
@@ -1,4 +1,4 @@
-<!-- Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+<!-- Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 By: BlueCat Networks
-Date: 2022-11-30
-Gateway Version: 22.11.1
+Date: 2023-04-05
+Gateway Version: 23.1.0
 Description: Example Gateway workflow
 -->
 
@@ -33,7 +33,6 @@ Description: Example Gateway workflow
 {% endblock %}
 
 {% block custom %}
-
     <p>{{ text['info'] }}</p>
     {% from "form_helper.html" import render_form %}
     {{ render_form(form, action=url_for('update_alias_recordupdate_alias_record_update_alias_record_page_form'), id="update_alias_record_form") }}

--- a/Examples/Alias Record/update_alias_record/update_alias_record_form.py
+++ b/Examples/Alias Record/update_alias_record/update_alias_record_form.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 # By: BlueCat Networks
-# Date: 2022-11-30
-# Gateway Version: 22.11.1
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
 # Description: Example Gateway workflow
 
 """

--- a/Examples/Alias Record/update_alias_record/update_alias_record_page.py
+++ b/Examples/Alias Record/update_alias_record/update_alias_record_page.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 # By: BlueCat Networks
-# Date: 2022-11-30
-# Gateway Version: 22.11.1
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
 # Description: Example Gateway workflow
 
 """

--- a/Examples/Alias Record/update_alias_record/update_alias_record_page.py
+++ b/Examples/Alias Record/update_alias_record/update_alias_record_page.py
@@ -58,7 +58,6 @@ def update_alias_record_update_alias_record_page():
         "update_alias_record_page.html",
         form=form,
         text=util.get_text(module_path(), config.language),
-        options=g.user.get_options(),
     )
 
 
@@ -112,7 +111,6 @@ def update_alias_record_update_alias_record_page_form():
                 "update_alias_record_page.html",
                 form=form,
                 text=util.get_text(module_path(), config.language),
-                options=g.user.get_options(),
             )
     else:
         g.user.logger.info("Form data was not valid.")
@@ -120,5 +118,4 @@ def update_alias_record_update_alias_record_page_form():
             "update_alias_record_page.html",
             form=form,
             text=util.get_text(module_path(), config.language),
-            options=g.user.get_options(),
         )

--- a/Examples/Deployment/__init__.py
+++ b/Examples/Deployment/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,6 @@
 # limitations under the License.
 #
 # By: BlueCat Networks
-# Date: 2022-11-30
-# Gateway Version: 22.11.1
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
 # Description: Example Gateway workflow

--- a/Examples/Deployment/selective_deployment/README.md
+++ b/Examples/Deployment/selective_deployment/README.md
@@ -1,8 +1,8 @@
 # **Example Selective Deployment Workflow**
 ## Select a DNS record for deployment
 
-**BlueCat Gateway Version:** 22.11.1 or greater <br/>
-**BAM version:** 9.2.0 or greater <br/>
+**BlueCat Gateway Version:** 23.1.0 or greater <br/>
+**BAM version:** 9.3.0 or greater <br/>
 
 ### Dependencies
 DNS/DHCP server appliances should be configured with necessary deployment roles and be under Address Manager control. Full deployment to DNS/DHCP server required prior to performing selective deployment. <br/>
@@ -51,4 +51,4 @@ When you are working with selective deployment, keep in mind the following:
   previous deployment, the status message of the previous deployment will be overwritten.
 ___
 
-©2020-2022 BlueCat Networks (USA) Inc. and its affiliates (collectively 'BlueCat'). All rights reserved.
+©2020-2023 BlueCat Networks (USA) Inc. and its affiliates (collectively 'BlueCat'). All rights reserved.

--- a/Examples/Deployment/selective_deployment/Selective_Deployment.txt
+++ b/Examples/Deployment/selective_deployment/Selective_Deployment.txt
@@ -1,8 +1,8 @@
-BlueCat Gateway 22.11.1
+BlueCat Gateway 23.1.0
 Example Selective deployment workflows
 
 Requirements: 
-• Address Manager v9.2.0 or greater.
+• Address Manager v9.3.0 or greater.
 • BDDS – BDDS appliances should be configured with necessary deployment roles and be under Address Manager control.
 
 In addition to Python wrappers for the Selective Deployment APIs, Example Selective Deployment workflows are now available on the BlueCat Labs GitHub repository, helping to complete BlueCat's Integrity solution of this API feature with UI-based Gateway workflows.

--- a/Examples/Deployment/selective_deployment/__init__.py
+++ b/Examples/Deployment/selective_deployment/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 # By: BlueCat Networks
-# Date: 2022-11-30
-# Gateway Version: 22.11.1
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
 # Description: Example Gateway workflow
 
 # pylint: disable=redefined-builtin

--- a/Examples/Deployment/selective_deployment/component_logic.py
+++ b/Examples/Deployment/selective_deployment/component_logic.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 # By: BlueCat Networks
-# Date: 2022-11-30
-# Gateway Version: 22.11.1
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
 # Description: Example Gateway workflow
 
 """This file is responsible for populating the out put table in selective deploy"""

--- a/Examples/Deployment/selective_deployment/css/selective_deployment_page.css
+++ b/Examples/Deployment/selective_deployment/css/selective_deployment_page.css
@@ -1,4 +1,4 @@
-/* Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+/* Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 By: BlueCat Networks
-Date: 2022-11-30
-Gateway Version: 22.11.1
+Date: 2023-04-05
+Gateway Version: 23.1.0
 Description: Example Gateway workflow
 */
 

--- a/Examples/Deployment/selective_deployment/js/selective_deployment_page.js
+++ b/Examples/Deployment/selective_deployment/js/selective_deployment_page.js
@@ -1,4 +1,4 @@
-// Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+// Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 // limitations under the License.
 //
 // By: BlueCat Networks
-// Date: 2022-11-30
-// Gateway Version: 22.11.1
+// Date: 2023-04-05
+// Gateway Version: 23.1.0
 // Description: Example Gateway workflow
 
 // JavaScript for your page goes in here.
@@ -105,13 +105,9 @@ function updateData(data_param){
     })
 }
 
-
-
-
 $(document).ready(function()
 {
     $('#deploy').click(deployData);
-
 });
 
 

--- a/Examples/Deployment/selective_deployment/selective_deployment_form.py
+++ b/Examples/Deployment/selective_deployment/selective_deployment_form.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 # By: BlueCat Networks
-# Date: 2022-11-30
-# Gateway Version: 22.11.1
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
 # Description: Example Gateway workflow
 
 """this file is used to add different elements into the page"""

--- a/Examples/Deployment/selective_deployment/selective_deployment_page.py
+++ b/Examples/Deployment/selective_deployment/selective_deployment_page.py
@@ -56,7 +56,6 @@ def selective_deployment_selective_deployment_page():
         "selective_deployment_page.html",
         form=form,
         text=util.get_text(module_path(), config.language),
-        options=g.user.get_options(),
     )
 
 

--- a/Examples/Deployment/selective_deployment/selective_deployment_page.py
+++ b/Examples/Deployment/selective_deployment/selective_deployment_page.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 # By: BlueCat Networks
-# Date: 2022-11-30
-# Gateway Version: 22.11.1
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
 # Description: Example Gateway workflow
 
 """this file is responsible to selective deploying certain dns records

--- a/Examples/Deployment/selective_deployment/templates/selective_deployment_page.html
+++ b/Examples/Deployment/selective_deployment/templates/selective_deployment_page.html
@@ -1,4 +1,4 @@
-<!-- Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+<!-- Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 By: BlueCat Networks
-Date: 2022-11-30
-Gateway Version: 22.11.1
+Date: 2023-04-05
+Gateway Version: 23.1.0
 Description: Example Gateway workflow
 -->
 
@@ -33,7 +33,6 @@ Description: Example Gateway workflow
 {% endblock %}
 
 {% block custom %}
-
     <p>{{ text['info'] }}</p>
     {% from "form_helper.html" import render_form %}
     {{ render_form(form, id="selective_deployment_form") }}

--- a/Examples/Host Record/README.md
+++ b/Examples/Host Record/README.md
@@ -1,9 +1,9 @@
 # **Example Host Record Workflows**
 ## Add, Delete, and Update Host Records
 
-**BlueCat Gateway Version:** 22.11.1 or greater <br/>
-**BAM version:** 9.2.0 or greater <br/>
+**BlueCat Gateway Version:** 23.1.0 or greater <br/>
+**BAM version:** 9.3.0 or greater <br/>
 **Dependencies:** Configuration, View, Zone, Block, and Network previously created in Address Manager <br/>
 **Description/Example Usage:** The Host (A) Record designates an IP address for a device. A new Host Record requires a name and an IP address. Using the Host Record workflow, you can add, delete, and update Host Records in a zone. This workflow is ideal for self-service customers using the BlueCat Gateway user interface and for IPAM or DNS administrators to help reduce the repetition usually associated with daily record management.
 
-©2020-2022 BlueCat Networks (USA) Inc. and its affiliates (collectively 'BlueCat'). All rights reserved.
+©2020-2023 BlueCat Networks (USA) Inc. and its affiliates (collectively 'BlueCat'). All rights reserved.

--- a/Examples/Host Record/__init__.py
+++ b/Examples/Host Record/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,6 @@
 # limitations under the License.
 #
 # By: BlueCat Networks
-# Date: 2022-11-30
-# Gateway Version: 22.11.1
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
 # Description: Example Gateway workflow

--- a/Examples/Host Record/add_host_record/__init__.py
+++ b/Examples/Host Record/add_host_record/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 # By: BlueCat Networks
-# Date: 2022-11-30
-# Gateway Version: 22.11.1
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
 # Description: Example Gateway workflow
 
 # pylint: disable=redefined-builtin,missing-docstring

--- a/Examples/Host Record/add_host_record/add_host_record_form.py
+++ b/Examples/Host Record/add_host_record/add_host_record_form.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 # By: BlueCat Networks
-# Date: 2022-11-30
-# Gateway Version: 22.11.1
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
 # Description: Example Gateway workflow
 
 """

--- a/Examples/Host Record/add_host_record/add_host_record_page.py
+++ b/Examples/Host Record/add_host_record/add_host_record_page.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 # By: BlueCat Networks
-# Date: 2022-11-30
-# Gateway Version: 22.11.1
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
 # Description: Example Gateway workflow
 
 """

--- a/Examples/Host Record/add_host_record/add_host_record_page.py
+++ b/Examples/Host Record/add_host_record/add_host_record_page.py
@@ -59,7 +59,6 @@ def add_host_record_add_host_record_page():
         "add_host_record_page.html",
         form=form,
         text=util.get_text(module_path(), config.language),
-        options=g.user.get_options(),
     )
 
 
@@ -112,7 +111,6 @@ def add_host_record_add_host_record_page_form():
                     form=form,
                     status_token=deploy_token,
                     text=util.get_text(module_path(), config.language),
-                    options=g.user.get_options(),
                 )
             return redirect(url_for("add_host_recordadd_host_record_add_host_record_page"))
         except Exception as e:
@@ -123,7 +121,6 @@ def add_host_record_add_host_record_page_form():
                 "add_host_record_page.html",
                 form=form,
                 text=util.get_text(module_path(), config.language),
-                options=g.user.get_options(),
             )
     else:
         g.user.logger.info("Form data was not valid.")
@@ -131,7 +128,6 @@ def add_host_record_add_host_record_page_form():
             "add_host_record_page.html",
             form=form,
             text=util.get_text(module_path(), config.language),
-            options=g.user.get_options(),
         )
 
 

--- a/Examples/Host Record/add_host_record/css/add_host_record_page.css
+++ b/Examples/Host Record/add_host_record/css/add_host_record_page.css
@@ -1,4 +1,4 @@
-/* Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+/* Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 By: BlueCat Networks
-Date: 2022-11-30
-Gateway Version: 22.11.1
+Date: 2023-04-05
+Gateway Version: 23.1.0
 Description: Example Gateway workflow
 */
 

--- a/Examples/Host Record/add_host_record/js/add_host_record_page.js
+++ b/Examples/Host Record/add_host_record/js/add_host_record_page.js
@@ -1,4 +1,4 @@
-// Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+// Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 // limitations under the License.
 //
 // By: BlueCat Networks
-// Date: 2022-11-30
-// Gateway Version: 22.11.1
+// Date: 2023-04-05
+// Gateway Version: 23.1.0
 // Description: Example Gateway workflow
 
 // JavaScript for your page goes in here.

--- a/Examples/Host Record/add_host_record/templates/add_host_record_page.html
+++ b/Examples/Host Record/add_host_record/templates/add_host_record_page.html
@@ -1,4 +1,4 @@
-<!-- Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+<!-- Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 By: BlueCat Networks
-Date: 2022-11-30
-Gateway Version: 22.11.1
+Date: 2023-04-05
+Gateway Version: 23.1.0
 Description: Example Gateway workflow
 -->
 

--- a/Examples/Host Record/delete_host_record/__init__.py
+++ b/Examples/Host Record/delete_host_record/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 # By: BlueCat Networks
-# Date: 2022-11-30
-# Gateway Version: 22.11.1
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
 # Description: Example Gateway workflow
 
 # pylint: disable=redefined-builtin,missing-docstring

--- a/Examples/Host Record/delete_host_record/css/delete_host_record_page.css
+++ b/Examples/Host Record/delete_host_record/css/delete_host_record_page.css
@@ -1,4 +1,4 @@
-/* Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+/* Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 By: BlueCat Networks
-Date: 2022-11-30
-Gateway Version: 22.11.1
+Date: 2023-04-05
+Gateway Version: 23.1.0
 Description: Example Gateway workflow
 */
 

--- a/Examples/Host Record/delete_host_record/delete_host_record_form.py
+++ b/Examples/Host Record/delete_host_record/delete_host_record_form.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 # By: BlueCat Networks
-# Date: 2022-11-30
-# Gateway Version: 22.11.1
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
 # Description: Example Gateway workflow
 
 """

--- a/Examples/Host Record/delete_host_record/delete_host_record_page.py
+++ b/Examples/Host Record/delete_host_record/delete_host_record_page.py
@@ -60,7 +60,6 @@ def delete_host_record_delete_host_record_page():
         "delete_host_record_page.html",
         form=form,
         text=util.get_text(module_path(), config.language),
-        options=g.user.get_options(),
     )
 
 
@@ -109,7 +108,6 @@ def delete_host_record_delete_host_record_page_form():
                     form=form,
                     status_token=deploy_token,
                     text=util.get_text(module_path(), config.language),
-                    options=g.user.get_options(),
                 )
             return redirect(url_for("delete_host_recorddelete_host_record_delete_host_record_page"))
         except Exception as e:
@@ -120,7 +118,6 @@ def delete_host_record_delete_host_record_page_form():
                 "delete_host_record_page.html",
                 form=form,
                 text=util.get_text(module_path(), config.language),
-                options=g.user.get_options(),
             )
     else:
         g.user.logger.info("Form data was not valid.")
@@ -128,7 +125,6 @@ def delete_host_record_delete_host_record_page_form():
             "delete_host_record_page.html",
             form=form,
             text=util.get_text(module_path(), config.language),
-            options=g.user.get_options(),
         )
 
 

--- a/Examples/Host Record/delete_host_record/delete_host_record_page.py
+++ b/Examples/Host Record/delete_host_record/delete_host_record_page.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 # By: BlueCat Networks
-# Date: 2022-11-30
-# Gateway Version: 22.11.1
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
 # Description: Example Gateway workflow
 
 """

--- a/Examples/Host Record/delete_host_record/js/delete_host_record_page.js
+++ b/Examples/Host Record/delete_host_record/js/delete_host_record_page.js
@@ -1,4 +1,4 @@
-// Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+// Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 // limitations under the License.
 //
 // By: BlueCat Networks
-// Date: 2022-11-30
-// Gateway Version: 22.11.1
+// Date: 2023-04-05
+// Gateway Version: 23.1.0
 // Description: Example Gateway workflow
 
 // JavaScript for your page goes in here.

--- a/Examples/Host Record/delete_host_record/templates/delete_host_record_page.html
+++ b/Examples/Host Record/delete_host_record/templates/delete_host_record_page.html
@@ -1,4 +1,4 @@
-<!-- Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+<!-- Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 By: BlueCat Networks
-Date: 2022-11-30
-Gateway Version: 22.11.1
+Date: 2023-04-05
+Gateway Version: 23.1.0
 Description: Example Gateway workflow
 -->
 

--- a/Examples/Host Record/update_host_record/__init__.py
+++ b/Examples/Host Record/update_host_record/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 # By: BlueCat Networks
-# Date: 2022-11-30
-# Gateway Version: 22.11.1
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
 # Description: Example Gateway workflow
 
 # pylint: disable=redefined-builtin,missing-docstring

--- a/Examples/Host Record/update_host_record/css/update_host_record_page.css
+++ b/Examples/Host Record/update_host_record/css/update_host_record_page.css
@@ -1,4 +1,4 @@
-/* Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+/* Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 By: BlueCat Networks
-Date: 2022-11-30
-Gateway Version: 22.11.1
+Date: 2023-04-05
+Gateway Version: 23.1.0
 Description: Example Gateway workflow
 */
 

--- a/Examples/Host Record/update_host_record/js/update_host_record_page.js
+++ b/Examples/Host Record/update_host_record/js/update_host_record_page.js
@@ -1,4 +1,4 @@
-// Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+// Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 // limitations under the License.
 //
 // By: BlueCat Networks
-// Date: 2022-11-30
-// Gateway Version: 22.11.1
+// Date: 2023-04-05
+// Gateway Version: 23.1.0
 // Description: Example Gateway workflow
 
 // JavaScript for your page goes in here.

--- a/Examples/Host Record/update_host_record/templates/update_host_record_page.html
+++ b/Examples/Host Record/update_host_record/templates/update_host_record_page.html
@@ -1,4 +1,4 @@
-<!-- Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+<!-- Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 By: BlueCat Networks
-Date: 2022-11-30
-Gateway Version: 22.11.1
+Date: 2023-04-05
+Gateway Version: 23.1.0
 Description: Example Gateway workflow
 -->
 

--- a/Examples/Host Record/update_host_record/update_host_record_form.py
+++ b/Examples/Host Record/update_host_record/update_host_record_form.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 # By: BlueCat Networks
-# Date: 2022-11-30
-# Gateway Version: 22.11.1
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
 # Description: Example Gateway workflow
 
 """

--- a/Examples/Host Record/update_host_record/update_host_record_page.py
+++ b/Examples/Host Record/update_host_record/update_host_record_page.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 # By: BlueCat Networks
-# Date: 2022-11-30
-# Gateway Version: 22.11.1
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
 # Description: Example Gateway workflow
 
 """

--- a/Examples/Host Record/update_host_record/update_host_record_page.py
+++ b/Examples/Host Record/update_host_record/update_host_record_page.py
@@ -60,7 +60,6 @@ def update_host_record_update_host_record_page():
         "update_host_record_page.html",
         form=form,
         text=util.get_text(module_path(), config.language),
-        options=g.user.get_options(),
     )
 
 
@@ -112,7 +111,6 @@ def update_host_record_update_host_record_page_form():
                         name=form.name.data,
                         ip4_address=form.ip4_address.data,
                         text=util.get_text(module_path(), config.language),
-                        options=g.user.get_options(),
                     )
 
             ip4_address = ",".join(ip4_address)
@@ -141,7 +139,6 @@ def update_host_record_update_host_record_page_form():
                     form=form,
                     status_token=deploy_token,
                     text=util.get_text(module_path(), config.language),
-                    options=g.user.get_options(),
                 )
             return redirect(url_for("update_host_recordupdate_host_record_update_host_record_page"))
         except Exception as e:
@@ -156,7 +153,6 @@ def update_host_record_update_host_record_page_form():
                 name=form.name.data,
                 ip4_address=form.ip4_address.data,
                 text=util.get_text(module_path(), config.language),
-                options=g.user.get_options(),
             )
     else:
         g.user.logger.info("Form data was not valid.")
@@ -168,7 +164,6 @@ def update_host_record_update_host_record_page_form():
             name=form.name.data,
             ip4_address=form.ip4_address.data,
             text=util.get_text(module_path(), config.language),
-            options=g.user.get_options(),
         )
 
 

--- a/Examples/IPv4 Address/README.md
+++ b/Examples/IPv4 Address/README.md
@@ -1,9 +1,9 @@
 # **Example IPv4 Address Workflows**
 ## Add DHCP and static IPv4 addresses, Delete, and Update IPv4 addresses
 
-**BlueCat Gateway Version:** 22.11.1 or greater <br/>
-**BAM version:** 9.2.0 or greater <br/>
+**BlueCat Gateway Version:** 23.1.0 or greater <br/>
+**BAM version:** 9.3.0 or greater <br/>
 **Dependencies:** Configuration, View, Zone, Block, and Network previously created in Address Manager <br/>
 **Description/Example Usage:** Using the IPv4 address workflow, you can add dynamic or static IPv4 addresses to a zone, and delete and update current IPv4 addresses in a zone. This workflow is ideal for self-service customers using the BlueCat Gateway user interface and for IPAM or DNS administrators to help reduce the repetition usually associated with daily record management.
 
-©2020-2022 BlueCat Networks (USA) Inc. and its affiliates (collectively 'BlueCat'). All rights reserved.
+©2020-2023 BlueCat Networks (USA) Inc. and its affiliates (collectively 'BlueCat'). All rights reserved.

--- a/Examples/IPv4 Address/__init__.py
+++ b/Examples/IPv4 Address/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,6 @@
 # limitations under the License.
 #
 # By: BlueCat Networks
-# Date: 2022-11-30
-# Gateway Version: 22.11.1
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
 # Description: Example Gateway workflow

--- a/Examples/IPv4 Address/add_dhcp_ip4_address/__init__.py
+++ b/Examples/IPv4 Address/add_dhcp_ip4_address/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 # By: BlueCat Networks
-# Date: 2022-11-30
-# Gateway Version: 22.11.1
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
 # Description: Example Gateway workflow
 
 # pylint: disable=redefined-builtin,missing-docstring

--- a/Examples/IPv4 Address/add_dhcp_ip4_address/add_dhcp_ip4_address_form.py
+++ b/Examples/IPv4 Address/add_dhcp_ip4_address/add_dhcp_ip4_address_form.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 # By: BlueCat Networks
-# Date: 2022-11-30
-# Gateway Version: 22.11.1
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
 # Description: Example Gateway workflow
 
 """

--- a/Examples/IPv4 Address/add_dhcp_ip4_address/add_dhcp_ip4_address_page.py
+++ b/Examples/IPv4 Address/add_dhcp_ip4_address/add_dhcp_ip4_address_page.py
@@ -60,7 +60,6 @@ def add_dhcp_ip4_address_add_dhcp_ip4_address_page():
         "add_dhcp_ip4_address_page.html",
         form=form,
         text=util.get_text(module_path(), config.language),
-        options=g.user.get_options(),
     )
 
 
@@ -122,7 +121,6 @@ def add_dhcp_ip4_address_add_dhcp_ip4_address_page_form():
                 "add_dhcp_ip4_address_page.html",
                 form=form,
                 text=util.get_text(module_path(), config.language),
-                options=g.user.get_options(),
             )
     else:
         g.user.logger.info("Form data was not valid.")
@@ -130,5 +128,4 @@ def add_dhcp_ip4_address_add_dhcp_ip4_address_page_form():
             "add_dhcp_ip4_address_page.html",
             form=form,
             text=util.get_text(module_path(), config.language),
-            options=g.user.get_options(),
         )

--- a/Examples/IPv4 Address/add_dhcp_ip4_address/add_dhcp_ip4_address_page.py
+++ b/Examples/IPv4 Address/add_dhcp_ip4_address/add_dhcp_ip4_address_page.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 # By: BlueCat Networks
-# Date: 2022-11-30
-# Gateway Version: 22.11.1
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
 # Description: Example Gateway workflow
 
 """

--- a/Examples/IPv4 Address/add_dhcp_ip4_address/css/add_dhcp_ip4_address_page.css
+++ b/Examples/IPv4 Address/add_dhcp_ip4_address/css/add_dhcp_ip4_address_page.css
@@ -1,4 +1,4 @@
-/* Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+/* Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 By: BlueCat Networks
-Date: 2022-11-30
-Gateway Version: 22.11.1
+Date: 2023-04-05
+Gateway Version: 23.1.0
 Description: Example Gateway workflow
 */
 

--- a/Examples/IPv4 Address/add_dhcp_ip4_address/js/add_dhcp_ip4_address_page.js
+++ b/Examples/IPv4 Address/add_dhcp_ip4_address/js/add_dhcp_ip4_address_page.js
@@ -1,4 +1,4 @@
-// Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+// Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 // limitations under the License.
 //
 // By: BlueCat Networks
-// Date: 2022-11-30
-// Gateway Version: 22.11.1
+// Date: 2023-04-05
+// Gateway Version: 23.1.0
 // Description: Example Gateway workflow
 
 // JavaScript for your page goes in here.

--- a/Examples/IPv4 Address/add_dhcp_ip4_address/templates/add_dhcp_ip4_address_page.html
+++ b/Examples/IPv4 Address/add_dhcp_ip4_address/templates/add_dhcp_ip4_address_page.html
@@ -1,4 +1,4 @@
-<!-- Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+<!-- Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 By: BlueCat Networks
-Date: 2022-11-30
-Gateway Version: 22.11.1
+Date: 2023-04-05
+Gateway Version: 23.1.0
 Description: Example Gateway workflow
 -->
 

--- a/Examples/IPv4 Address/add_static_ip4_address/__init__.py
+++ b/Examples/IPv4 Address/add_static_ip4_address/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 # By: BlueCat Networks
-# Date: 2022-11-30
-# Gateway Version: 22.11.1
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
 # Description: Example Gateway workflow
 
 # pylint: disable=redefined-builtin,missing-docstring

--- a/Examples/IPv4 Address/add_static_ip4_address/add_static_ip4_address_form.py
+++ b/Examples/IPv4 Address/add_static_ip4_address/add_static_ip4_address_form.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 # By: BlueCat Networks
-# Date: 2022-11-30
-# Gateway Version: 22.11.1
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
 # Description: Example Gateway workflow
 
 """

--- a/Examples/IPv4 Address/add_static_ip4_address/add_static_ip4_address_page.py
+++ b/Examples/IPv4 Address/add_static_ip4_address/add_static_ip4_address_page.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 # By: BlueCat Networks
-# Date: 2022-11-30
-# Gateway Version: 22.11.1
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
 # Description: Example Gateway workflow
 
 """

--- a/Examples/IPv4 Address/add_static_ip4_address/add_static_ip4_address_page.py
+++ b/Examples/IPv4 Address/add_static_ip4_address/add_static_ip4_address_page.py
@@ -58,7 +58,6 @@ def add_static_ip4_address_add_static_ip4_address_page():
         "add_static_ip4_address_page.html",
         form=form,
         text=util.get_text(module_path(), config.language),
-        options=g.user.get_options(),
     )
 
 
@@ -129,7 +128,6 @@ def add_static_ip4_address_add_static_ip4_address_page_form():
                 "add_static_ip4_address_page.html",
                 form=form,
                 text=util.get_text(module_path(), config.language),
-                options=g.user.get_options(),
             )
     else:
         g.user.logger.info("Form data was not valid.")
@@ -137,5 +135,4 @@ def add_static_ip4_address_add_static_ip4_address_page_form():
             "add_static_ip4_address_page.html",
             form=form,
             text=util.get_text(module_path(), config.language),
-            options=g.user.get_options(),
         )

--- a/Examples/IPv4 Address/add_static_ip4_address/css/add_static_ip4_address_page.css
+++ b/Examples/IPv4 Address/add_static_ip4_address/css/add_static_ip4_address_page.css
@@ -1,4 +1,4 @@
-/* Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+/* Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 By: BlueCat Networks
-Date: 2022-11-30
-Gateway Version: 22.11.1
+Date: 2023-04-05
+Gateway Version: 23.1.0
 Description: Example Gateway workflow
 */
 
@@ -27,18 +27,18 @@ Description: Example Gateway workflow
 }
 
 ul.ui-autocomplete {
-            max-height: 80px;
-            width: 80px;
-            overflow-y:scroll;
+    max-height: 80px;
+    width: 80px;
+    overflow-y:scroll;
 
-            font-weight:normal;
-            font-style: normal;
-            font-size: inherit;
-            font-family: inherit;
-            background-color: #B2BBC8;
-            color: black;
-            border-radius:4px;
-            border:1px solid #AAAAAA;
+    font-weight:normal;
+    font-style: normal;
+    font-size: inherit;
+    font-family: inherit;
+    background-color: #B2BBC8;
+    color: black;
+    border-radius:4px;
+    border:1px solid #AAAAAA;
 }
 
 .ui-helper-hidden-accessible { display:none; }

--- a/Examples/IPv4 Address/add_static_ip4_address/js/add_static_ip4_address_page.js
+++ b/Examples/IPv4 Address/add_static_ip4_address/js/add_static_ip4_address_page.js
@@ -1,4 +1,4 @@
-// Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+// Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 // limitations under the License.
 //
 // By: BlueCat Networks
-// Date: 2022-11-30
-// Gateway Version: 22.11.1
+// Date: 2023-04-05
+// Gateway Version: 23.1.0
 // Description: Example Gateway workflow
 
 // JavaScript for your page goes in here.
@@ -26,8 +26,9 @@ function reset_hostname() {
     if ($("#zone").val() == '') {
         $("#hostname").val('');
         $("#hostname").attr("disabled", true);
+    } else {
+        $("#hostname").attr("disabled", false);
     }
-    else {$("#hostname").attr("disabled", false);}
 }
 
 function view_changed() {

--- a/Examples/IPv4 Address/add_static_ip4_address/templates/add_static_ip4_address_page.html
+++ b/Examples/IPv4 Address/add_static_ip4_address/templates/add_static_ip4_address_page.html
@@ -1,4 +1,4 @@
-<!-- Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+<!-- Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 By: BlueCat Networks
-Date: 2022-11-30
-Gateway Version: 22.11.1
+Date: 2023-04-05
+Gateway Version: 23.1.0
 Description: Example Gateway workflow
 -->
 
@@ -33,7 +33,6 @@ Description: Example Gateway workflow
 {% endblock %}
 
 {% block custom %}
-
     <p>{{ text['info'] }}</p>
     {% from "form_helper.html" import render_form %}
     {{ render_form(form, action=url_for('add_static_ip4_addressadd_static_ip4_address_add_static_ip4_address_page_form'), id="add_static_ip4_address_form") }}

--- a/Examples/IPv4 Address/delete_ip4_address/__init__.py
+++ b/Examples/IPv4 Address/delete_ip4_address/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 # By: BlueCat Networks
-# Date: 2022-11-30
-# Gateway Version: 22.11.1
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
 # Description: Example Gateway workflow
 
 # pylint: disable=redefined-builtin,missing-docstring

--- a/Examples/IPv4 Address/delete_ip4_address/css/delete_ip4_address_page.css
+++ b/Examples/IPv4 Address/delete_ip4_address/css/delete_ip4_address_page.css
@@ -1,4 +1,4 @@
-/* Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+/* Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 By: BlueCat Networks
-Date: 2022-11-30
-Gateway Version: 22.11.1
+Date: 2023-04-05
+Gateway Version: 23.1.0
 Description: Example Gateway workflow
 */
 
@@ -27,18 +27,18 @@ Description: Example Gateway workflow
 }
 
 ul.ui-autocomplete {
-            max-height: 80px;
-            width: 80px;
-            overflow-y:scroll;
+    max-height: 80px;
+    width: 80px;
+    overflow-y:scroll;
 
-            font-weight:normal;
-            font-style: normal;
-            font-size: inherit;
-            font-family: inherit;
-            background-color: #B2BBC8;
-            color: black;
-            border-radius:4px;
-            border:1px solid #AAAAAA;
+    font-weight:normal;
+    font-style: normal;
+    font-size: inherit;
+    font-family: inherit;
+    background-color: #B2BBC8;
+    color: black;
+    border-radius:4px;
+    border:1px solid #AAAAAA;
 }
 
 .ui-helper-hidden-accessible { display:none; }

--- a/Examples/IPv4 Address/delete_ip4_address/delete_ip4_address_form.py
+++ b/Examples/IPv4 Address/delete_ip4_address/delete_ip4_address_form.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 # By: BlueCat Networks
-# Date: 2022-11-30
-# Gateway Version: 22.11.1
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
 # Description: Example Gateway workflow
 
 """

--- a/Examples/IPv4 Address/delete_ip4_address/delete_ip4_address_page.py
+++ b/Examples/IPv4 Address/delete_ip4_address/delete_ip4_address_page.py
@@ -56,7 +56,6 @@ def delete_ip4_address_delete_ip4_address_page():
         "delete_ip4_address_page.html",
         form=form,
         text=util.get_text(module_path(), config.language),
-        options=g.user.get_options(),
     )
 
 
@@ -104,7 +103,6 @@ def delete_ip4_address_delete_ip4_address_page_form():
                 "delete_ip4_address_page.html",
                 form=form,
                 text=util.get_text(module_path(), config.language),
-                options=g.user.get_options(),
             )
     else:
         g.user.logger.info("Form data was not valid.")
@@ -112,5 +110,4 @@ def delete_ip4_address_delete_ip4_address_page_form():
             "delete_ip4_address_page.html",
             form=form,
             text=util.get_text(module_path(), config.language),
-            options=g.user.get_options(),
         )

--- a/Examples/IPv4 Address/delete_ip4_address/delete_ip4_address_page.py
+++ b/Examples/IPv4 Address/delete_ip4_address/delete_ip4_address_page.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 # By: BlueCat Networks
-# Date: 2022-11-30
-# Gateway Version: 22.11.1
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
 # Description: Example Gateway workflow
 
 """

--- a/Examples/IPv4 Address/delete_ip4_address/js/delete_ip4_address_page.js
+++ b/Examples/IPv4 Address/delete_ip4_address/js/delete_ip4_address_page.js
@@ -1,4 +1,4 @@
-// Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+// Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 // limitations under the License.
 //
 // By: BlueCat Networks
-// Date: 2022-11-30
-// Gateway Version: 22.11.1
+// Date: 2023-04-05
+// Gateway Version: 23.1.0
 // Description: Example Gateway workflow
 
 // JavaScript for your page goes in here.

--- a/Examples/IPv4 Address/delete_ip4_address/templates/delete_ip4_address_page.html
+++ b/Examples/IPv4 Address/delete_ip4_address/templates/delete_ip4_address_page.html
@@ -1,4 +1,4 @@
-<!-- Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+<!-- Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 By: BlueCat Networks
-Date: 2022-11-30
-Gateway Version: 22.11.1
+Date: 2023-04-05
+Gateway Version: 23.1.0
 Description: Example Gateway workflow
 -->
 
@@ -33,11 +33,9 @@ Description: Example Gateway workflow
 {% endblock %}
 
 {% block custom %}
-
     <p>{{ text['info'] }}</p>
     {% from "form_helper.html" import render_form %}
     {{ render_form(form, action=url_for('delete_ip4_addressdelete_ip4_address_delete_ip4_address_page_form'), id="delete_ip_form") }}
-
 {% endblock %}
 
 {% block scripts %}

--- a/Examples/IPv4 Address/update_ip4_address/__init__.py
+++ b/Examples/IPv4 Address/update_ip4_address/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 # By: BlueCat Networks
-# Date: 2022-11-30
-# Gateway Version: 22.11.1
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
 # Description: Example Gateway workflow
 
 # pylint: disable=redefined-builtin,missing-docstring

--- a/Examples/IPv4 Address/update_ip4_address/css/update_ip4_address_page.css
+++ b/Examples/IPv4 Address/update_ip4_address/css/update_ip4_address_page.css
@@ -1,4 +1,4 @@
-/* Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+/* Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 By: BlueCat Networks
-Date: 2022-11-30
-Gateway Version: 22.11.1
+Date: 2023-04-05
+Gateway Version: 23.1.0
 Description: Example Gateway workflow
 */
 

--- a/Examples/IPv4 Address/update_ip4_address/js/update_ip4_address_page.js
+++ b/Examples/IPv4 Address/update_ip4_address/js/update_ip4_address_page.js
@@ -1,4 +1,4 @@
-// Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+// Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 // limitations under the License.
 //
 // By: BlueCat Networks
-// Date: 2022-11-30
-// Gateway Version: 22.11.1
+// Date: 2023-04-05
+// Gateway Version: 23.1.0
 // Description: Example Gateway workflow
 
 // JavaScript for your page goes in here.

--- a/Examples/IPv4 Address/update_ip4_address/update_ip4_address_form.py
+++ b/Examples/IPv4 Address/update_ip4_address/update_ip4_address_form.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 # By: BlueCat Networks
-# Date: 2022-11-30
-# Gateway Version: 22.11.1
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
 # Description: Example Gateway workflow
 
 """

--- a/Examples/IPv4 Address/update_ip4_address/update_ip4_address_page.py
+++ b/Examples/IPv4 Address/update_ip4_address/update_ip4_address_page.py
@@ -57,7 +57,6 @@ def update_ip4_address_update_ip4_address_page():
         "update_ip4_address_page.html",
         form=form,
         text=util.get_text(module_path(), config.language),
-        options=g.user.get_options(),
     )
 
 
@@ -103,7 +102,6 @@ def update_ip4_address_update_ip4_address_page_form():
                 "update_ip4_address_page.html",
                 form=form,
                 text=util.get_text(module_path(), config.language),
-                options=g.user.get_options(),
             )
     else:
         g.user.logger.info("Form data was not valid.")
@@ -111,5 +109,4 @@ def update_ip4_address_update_ip4_address_page_form():
             "update_ip4_address_page.html",
             form=form,
             text=util.get_text(module_path(), config.language),
-            options=g.user.get_options(),
         )

--- a/Examples/IPv4 Address/update_ip4_address/update_ip4_address_page.py
+++ b/Examples/IPv4 Address/update_ip4_address/update_ip4_address_page.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 # By: BlueCat Networks
-# Date: 2022-11-30
-# Gateway Version: 22.11.1
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
 # Description: Example Gateway workflow
 
 """

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -1,4 +1,4 @@
-<!-- Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates -->
+<!-- Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates -->
 
 # **BlueCat Gateway Example Workflows**
 

--- a/Examples/Text Record/README.md
+++ b/Examples/Text Record/README.md
@@ -1,9 +1,9 @@
 # **Example Text Record Workflows**
 ## Add, Delete, and Update Text Records
 
-**BlueCat Gateway Version:** 22.11.1 or greater <br/>
-**BAM version:** 9.2.0 or greater <br/>
+**BlueCat Gateway Version:** 23.1.0 or greater <br/>
+**BAM version:** 9.3.0 or greater <br/>
 **Dependencies:** Configuration, View, and Zone previously created in Address Manager <br/>
 **Description/Example Usage:** The Text Record includes name and text information, and associates arbitrary text with a host name. In addition, the Text Record is used to support record types such as those used in Sender Policy Framework (SPF) e-mail validation. Using the Text Record workflow, you can add, delete, or update Text Records in a zone. This workflow is ideal for self-service customers using the BlueCat Gateway user interface and for IPAM or DNS administrators to help reduce the repetition usually associated with daily record management.
 
-©2020-2022 BlueCat Networks (USA) Inc. and its affiliates (collectively 'BlueCat'). All rights reserved.
+©2020-2023 BlueCat Networks (USA) Inc. and its affiliates (collectively 'BlueCat'). All rights reserved.

--- a/Examples/Text Record/__init__.py
+++ b/Examples/Text Record/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,6 @@
 # limitations under the License.
 #
 # By: BlueCat Networks
-# Date: 2022-11-30
-# Gateway Version: 22.11.1
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
 # Description: Example Gateway workflow

--- a/Examples/Text Record/add_text_record/__init__.py
+++ b/Examples/Text Record/add_text_record/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 # By: BlueCat Networks
-# Date: 2022-11-30
-# Gateway Version: 22.11.1
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
 # Description: Example Gateway workflow
 
 # pylint: disable=redefined-builtin,missing-docstring

--- a/Examples/Text Record/add_text_record/add_text_record_form.py
+++ b/Examples/Text Record/add_text_record/add_text_record_form.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 # By: BlueCat Networks
-# Date: 2022-11-30
-# Gateway Version: 22.11.1
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
 # Description: Example Gateway workflow
 
 """

--- a/Examples/Text Record/add_text_record/add_text_record_page.py
+++ b/Examples/Text Record/add_text_record/add_text_record_page.py
@@ -56,7 +56,6 @@ def add_text_record_add_text_record_page():
         "add_text_record_page.html",
         form=form,
         text=util.get_text(module_path(), config.language),
-        uoptions=g.user.get_options(),
     )
 
 
@@ -105,7 +104,6 @@ def add_text_record_add_text_record_page_form():
                 "add_text_record_page.html",
                 form=form,
                 text=util.get_text(module_path(), config.language),
-                options=g.user.get_options(),
             )
     else:
         g.user.logger.info("Form data was not valid.")
@@ -113,5 +111,4 @@ def add_text_record_add_text_record_page_form():
             "add_text_record_page.html",
             form=form,
             text=util.get_text(module_path(), config.language),
-            options=g.user.get_options(),
         )

--- a/Examples/Text Record/add_text_record/add_text_record_page.py
+++ b/Examples/Text Record/add_text_record/add_text_record_page.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 # By: BlueCat Networks
-# Date: 2022-11-30
-# Gateway Version: 22.11.1
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
 # Description: Example Gateway workflow
 
 """

--- a/Examples/Text Record/add_text_record/css/add_text_record_page.css
+++ b/Examples/Text Record/add_text_record/css/add_text_record_page.css
@@ -1,4 +1,4 @@
-/* Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+/* Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 By: BlueCat Networks
-Date: 2022-11-30
-Gateway Version: 22.11.1
+Date: 2023-04-05
+Gateway Version: 23.1.0
 Description: Example Gateway workflow
 */
 

--- a/Examples/Text Record/add_text_record/js/add_text_record_page.js
+++ b/Examples/Text Record/add_text_record/js/add_text_record_page.js
@@ -1,4 +1,4 @@
-// Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+// Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 // limitations under the License.
 //
 // By: BlueCat Networks
-// Date: 2022-11-30
-// Gateway Version: 22.11.1
+// Date: 2023-04-05
+// Gateway Version: 23.1.0
 // Description: Example Gateway workflow
 
 // JavaScript for your page goes in here.

--- a/Examples/Text Record/add_text_record/templates/add_text_record_page.html
+++ b/Examples/Text Record/add_text_record/templates/add_text_record_page.html
@@ -1,4 +1,4 @@
-<!-- Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+<!-- Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 By: BlueCat Networks
-Date: 2022-11-30
-Gateway Version: 22.11.1
+Date: 2023-04-05
+Gateway Version: 23.1.0
 Description: Example Gateway workflow
 -->
 
@@ -33,11 +33,9 @@ Description: Example Gateway workflow
 {% endblock %}
 
 {% block custom %}
-
     <p>{{ text['info'] }}</p>
     {% from "form_helper.html" import render_form %}
     {{ render_form(form, action=url_for('add_text_recordadd_text_record_add_text_record_page_form'), id="add_text_form") }}
-
 {% endblock %}
 
 {% block scripts %}

--- a/Examples/Text Record/delete_text_record/__init__.py
+++ b/Examples/Text Record/delete_text_record/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 # By: BlueCat Networks
-# Date: 2022-11-30
-# Gateway Version: 22.11.1
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
 # Description: Example Gateway workflow
 
 # pylint: disable=redefined-builtin,missing-docstring

--- a/Examples/Text Record/delete_text_record/css/delete_text_record_page.css
+++ b/Examples/Text Record/delete_text_record/css/delete_text_record_page.css
@@ -1,4 +1,4 @@
-/* Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+/* Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 By: BlueCat Networks
-Date: 2022-11-30
-Gateway Version: 22.11.1
+Date: 2023-04-05
+Gateway Version: 23.1.0
 Description: Example Gateway workflow
 */
 

--- a/Examples/Text Record/delete_text_record/delete_text_record_form.py
+++ b/Examples/Text Record/delete_text_record/delete_text_record_form.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 # By: BlueCat Networks
-# Date: 2022-11-30
-# Gateway Version: 22.11.1
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
 # Description: Example Gateway workflow
 
 """

--- a/Examples/Text Record/delete_text_record/delete_text_record_page.py
+++ b/Examples/Text Record/delete_text_record/delete_text_record_page.py
@@ -58,7 +58,6 @@ def delete_text_record_delete_text_record_page():
         "delete_text_record_page.html",
         form=form,
         text=util.get_text(module_path(), config.language),
-        options=g.user.get_options(),
     )
 
 
@@ -110,7 +109,6 @@ def delete_text_record_delete_text_record_page_form():
                 "delete_text_record_page.html",
                 form=form,
                 text=util.get_text(module_path(), config.language),
-                options=g.user.get_options(),
             )
     else:
         g.user.logger.info("Form data was not valid.")
@@ -119,5 +117,4 @@ def delete_text_record_delete_text_record_page_form():
             "delete_text_record_page.html",
             form=form,
             text=util.get_text(module_path(), config.language),
-            options=g.user.get_options(),
         )

--- a/Examples/Text Record/delete_text_record/delete_text_record_page.py
+++ b/Examples/Text Record/delete_text_record/delete_text_record_page.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 # By: BlueCat Networks
-# Date: 2022-11-30
-# Gateway Version: 22.11.1
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
 # Description: Example Gateway workflow
 
 """

--- a/Examples/Text Record/delete_text_record/js/delete_text_record_page.js
+++ b/Examples/Text Record/delete_text_record/js/delete_text_record_page.js
@@ -1,4 +1,4 @@
-// Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+// Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 // limitations under the License.
 //
 // By: BlueCat Networks
-// Date: 2022-11-30
-// Gateway Version: 22.11.1
+// Date: 2023-04-05
+// Gateway Version: 23.1.0
 // Description: Example Gateway workflow
 
 // JavaScript for your page goes in here.

--- a/Examples/Text Record/delete_text_record/templates/delete_text_record_page.html
+++ b/Examples/Text Record/delete_text_record/templates/delete_text_record_page.html
@@ -1,4 +1,4 @@
-<!-- Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+<!-- Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 By: BlueCat Networks
-Date: 2022-11-30
-Gateway Version: 22.11.1
+Date: 2023-04-05
+Gateway Version: 23.1.0
 Description: Example Gateway workflow
 -->
 
@@ -33,7 +33,6 @@ Description: Example Gateway workflow
 {% endblock %}
 
 {% block custom %}
-
     <p>{{ text['info'] }}</p>
     {% from "form_helper.html" import render_form %}
     {{ render_form(form, action=url_for('delete_text_recorddelete_text_record_delete_text_record_page_form'), id="delete_text_form") }}

--- a/Examples/Text Record/update_text_record/__init__.py
+++ b/Examples/Text Record/update_text_record/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 # By: BlueCat Networks
-# Date: 2022-11-30
-# Gateway Version: 22.11.1
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
 # Description: Example Gateway workflow
 
 # pylint: disable=redefined-builtin,missing-docstring

--- a/Examples/Text Record/update_text_record/css/update_text_record_page.css
+++ b/Examples/Text Record/update_text_record/css/update_text_record_page.css
@@ -1,4 +1,4 @@
-/* Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+/* Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 By: BlueCat Networks
-Date: 2022-11-30
-Gateway Version: 22.11.1
+Date: 2023-04-05
+Gateway Version: 23.1.0
 Description: Example Gateway workflow
 */
 

--- a/Examples/Text Record/update_text_record/js/update_text_record_page.js
+++ b/Examples/Text Record/update_text_record/js/update_text_record_page.js
@@ -1,4 +1,4 @@
-// Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+// Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 // limitations under the License.
 //
 // By: BlueCat Networks
-// Date: 2022-11-30
-// Gateway Version: 22.11.1
+// Date: 2023-04-05
+// Gateway Version: 23.1.0
 // Description: Example Gateway workflow
 
 // JavaScript for your page goes in here.

--- a/Examples/Text Record/update_text_record/templates/update_text_record_page.html
+++ b/Examples/Text Record/update_text_record/templates/update_text_record_page.html
@@ -1,4 +1,4 @@
-<!-- Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+<!-- Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 By: BlueCat Networks
-Date: 2022-11-30
-Gateway Version: 22.11.1
+Date: 2023-04-05
+Gateway Version: 23.1.0
 Description: Example Gateway workflow
 -->
 
@@ -33,7 +33,6 @@ Description: Example Gateway workflow
 {% endblock %}
 
 {% block custom %}
-
     <p>{{ text['info'] }}</p>
     {% from "form_helper.html" import render_form %}
     {{ render_form(form, action=url_for('update_text_recordupdate_text_record_update_text_record_page_form'), id="update_alias_record_form") }}

--- a/Examples/Text Record/update_text_record/update_text_record_form.py
+++ b/Examples/Text Record/update_text_record/update_text_record_form.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 # By: BlueCat Networks
-# Date: 2022-11-30
-# Gateway Version: 22.11.1
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
 # Description: Example Gateway workflow
 
 """

--- a/Examples/Text Record/update_text_record/update_text_record_page.py
+++ b/Examples/Text Record/update_text_record/update_text_record_page.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 # By: BlueCat Networks
-# Date: 2022-11-30
-# Gateway Version: 22.11.1
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
 # Description: Example Gateway workflow
 
 """

--- a/Examples/Text Record/update_text_record/update_text_record_page.py
+++ b/Examples/Text Record/update_text_record/update_text_record_page.py
@@ -58,7 +58,6 @@ def update_text_record_update_text_record_page():
         "update_text_record_page.html",
         form=form,
         text=util.get_text(module_path(), config.language),
-        options=g.user.get_options(),
     )
 
 
@@ -105,7 +104,6 @@ def update_text_record_update_text_record_page_form():
                 "update_text_record_page.html",
                 form=form,
                 text=util.get_text(module_path(), config.language),
-                options=g.user.get_options(),
             )
 
     else:
@@ -117,5 +115,4 @@ def update_text_record_update_text_record_page_form():
             "update_text_record_page.html",
             form=form,
             text=util.get_text(module_path(), config.language),
-            options=g.user.get_options(),
         )

--- a/Examples/UI Components/README.md
+++ b/Examples/UI Components/README.md
@@ -1,9 +1,9 @@
 # **Example UI Table Component Workflows**
 ## Search for UI Table Components
 
-**BlueCat Gateway Version:** 22.11.1 or greater <br/>
-**BAM version:** 9.2.0 or greater <br/>
+**BlueCat Gateway Version:** 23.1.0 or greater <br/>
+**BAM version:** 9.3.0 or greater <br/>
 **Dependencies:** None <br/>
 **Description/Example Usage:** The UI Table Components workflow provides an example of generating a table of search results in a UI workflow. It returns an array of entities by searching for keywords associated with objects of a specified object type. You can search for an object type using a keyword. This workflow is intended for customers to familiarize themselves with how to build a table component in their UI workflows.
 
-©2020-2022 BlueCat Networks (USA) Inc. and its affiliates (collectively 'BlueCat'). All rights reserved.
+©2020-2023 BlueCat Networks (USA) Inc. and its affiliates (collectively 'BlueCat'). All rights reserved.

--- a/Examples/UI Components/__init__.py
+++ b/Examples/UI Components/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,6 @@
 # limitations under the License.
 #
 # By: BlueCat Networks
-# Date: 2022-11-30
-# Gateway Version: 22.11.1
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
 # Description: Example Gateway workflow

--- a/Examples/UI Components/table_component/__init__.py
+++ b/Examples/UI Components/table_component/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 # By: BlueCat Networks
-# Date: 2022-11-30
-# Gateway Version: 22.11.1
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
 # Description: Example Gateway workflow
 
 # pylint: disable=redefined-builtin,missing-docstring

--- a/Examples/UI Components/table_component/component_logic.py
+++ b/Examples/UI Components/table_component/component_logic.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 # By: BlueCat Networks
-# Date: 2022-11-30
-# Gateway Version: 22.11.1
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
 # Description: Example Gateway workflow
 
 """

--- a/Examples/UI Components/table_component/css/table_component_page.css
+++ b/Examples/UI Components/table_component/css/table_component_page.css
@@ -1,4 +1,4 @@
-/* Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+/* Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,13 +13,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 By: BlueCat Networks
-Date: 2022-11-30
-Gateway Version: 22.11.1
+Date: 2023-04-05
+Gateway Version: 23.1.0
 Description: Example Gateway workflow
 */
 
 /* Custom styles for your page go in here. */
-div#search_message_field{
+div#search_message_field {
   padding-left: 100px;
   padding-top: 10px;
 }

--- a/Examples/UI Components/table_component/js/table_component_page.js
+++ b/Examples/UI Components/table_component/js/table_component_page.js
@@ -1,4 +1,4 @@
-// Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+// Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 // limitations under the License.
 //
 // By: BlueCat Networks
-// Date: 2022-11-30
-// Gateway Version: 22.11.1
+// Date: 2023-04-05
+// Gateway Version: 23.1.0
 // Description: Example Gateway workflow
 
 // JavaScript for your page goes in here.

--- a/Examples/UI Components/table_component/table_component_form.py
+++ b/Examples/UI Components/table_component/table_component_form.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 # By: BlueCat Networks
-# Date: 2022-11-30
-# Gateway Version: 22.11.1
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
 # Description: Example Gateway workflow
 
 """

--- a/Examples/UI Components/table_component/table_component_page.py
+++ b/Examples/UI Components/table_component/table_component_page.py
@@ -22,7 +22,7 @@ Table component page
 """
 import os
 
-from flask import render_template, g
+from flask import render_template
 
 from bluecat import route
 from bluecat import util
@@ -58,5 +58,4 @@ def table_component_table_component_page():
         "table_component_page.html",
         form=form,
         text=util.get_text(module_path(), config.language),
-        options=g.user.get_options(),
     )

--- a/Examples/UI Components/table_component/table_component_page.py
+++ b/Examples/UI Components/table_component/table_component_page.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 # By: BlueCat Networks
-# Date: 2022-11-30
-# Gateway Version: 22.11.1
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
 # Description: Example Gateway workflow
 
 """

--- a/Examples/UI Components/table_component/templates/table_component_page.html
+++ b/Examples/UI Components/table_component/templates/table_component_page.html
@@ -1,4 +1,4 @@
-<!-- Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+<!-- Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 By: BlueCat Networks
-Date: 2022-11-30
-Gateway Version: 22.11.1
+Date: 2023-04-05
+Gateway Version: 23.1.0
 Description: Example Gateway workflow
 -->
 
@@ -33,12 +33,10 @@ Description: Example Gateway workflow
 {% endblock %}
 
 {% block custom %}
-
     <p>{{ text['info'] }}</p>
     <!--Your page's HTML goes here.-->
     {% from "form_helper.html" import render_form %}
     {{ render_form(form, id="table_component_page_form") }}
-
 {% endblock %}
 
 {% block scripts %}

--- a/Examples/nav_zones/README.md
+++ b/Examples/nav_zones/README.md
@@ -1,0 +1,10 @@
+# **Example Navigate Zones**
+## An example workflow using both REST v1 and REST v2
+
+
+**BlueCat Gateway Version:** 23.1.0 or greater <br/>
+**BAM version:** 9.3.0 or greater <br/>
+**Dependencies:** Configuration, View, Zone, previously created in Address Manager <br/>
+**Description/Example Usage:**  This workflow demonstrates an example on how a workflow can work with both REST API v1 and REST API v2 when connected to different versions of Address Manager. It retrieves the configurations on an Address Manager and based on the selection it later retrieves the views and zones. 
+
+©2023 BlueCat Networks (USA) Inc. and its affiliates (collectively 'BlueCat'). All rights reserved.

--- a/Examples/nav_zones/__init__.py
+++ b/Examples/nav_zones/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,4 +15,15 @@
 # By: BlueCat Networks
 # Date: 2023-04-05
 # Gateway Version: 23.1.0
-# Description: Example Gateway workflows
+# Description: Gateway workflow to demonstrate use of REST API v2 client.
+
+# pylint: disable=redefined-builtin,missing-docstring
+type = "ui"
+sub_pages = [
+    {
+        "name": "nav_zones_page",
+        "title": "Navigate zones",
+        "endpoint": "nav_zones",
+        "description": "Navigate zones",
+    },
+]

--- a/Examples/nav_zones/js/nav_zones.js
+++ b/Examples/nav_zones/js/nav_zones.js
@@ -1,0 +1,84 @@
+// Copyright 2023 BlueCat Networks (USA) Inc. and its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// By: BlueCat Networks
+// Date: 2023-04-05
+// Gateway Version: 23.1.0
+// Description: Gateway workflow to demonstrate use of REST API v2 client.
+
+// JavaScript for your page goes in here.
+$(document).ready(function() {
+
+});
+
+const clearChildren = (dst) => {
+    while (dst.lastChild) {
+        dst.removeChild(dst.lastChild);
+    }
+};
+
+fetch("/nav_zones/api/v1/configurations")
+    .then((response) => response.json())
+    .then((data) => {
+        const dst = document.querySelector("#configurations");
+        clearChildren(dst);
+        data.forEach((item) => {
+            const el = document.createElement("option");
+            el.value = item.id;
+            el.innerText = item.name;
+            dst.appendChild(el);
+        })
+    });
+
+document.querySelector("#configurations")
+    .addEventListener("change", (e, x) => {
+        const vs = document.querySelector("#views");
+        const zs = document.querySelector("#zones");
+        clearChildren(vs);
+        clearChildren(zs);
+        const pid = e.target.selectedOptions[0].value;
+        console.log("Will retrieve views for configurations with ID " + pid);
+        fetch("/nav_zones/api/v1/views/?parent_id=" + pid)
+            .then((response) => response.json())
+            .then((data) => {
+                const dst = document.querySelector("#views");
+                clearChildren(dst);
+                data.forEach((item) => {
+                    const el = document.createElement("option");
+                    el.value = item.id;
+                    el.innerText = item.name;
+                    dst.appendChild(el);
+                })
+            });
+    });
+
+document.querySelector("#views")
+    .addEventListener("change", (e, x) => {
+        const zs = document.querySelector("#zones");
+        clearChildren(zs);
+        const pid = e.target.selectedOptions[0].value;
+        console.log("Will retrieve zones for view with ID " + pid);
+        fetch("/nav_zones/api/v1/zones/?parent_id=" + pid)
+            .then((response) => response.json())
+            .then((data) => {
+                const dst = document.querySelector("#zones");
+                clearChildren(dst);
+                data.forEach((item) => {
+                    const el = document.createElement("option");
+                    el.value = item.id;
+                    el.innerText = item.name;
+                    dst.appendChild(el);
+                })
+            });
+    });

--- a/Examples/nav_zones/nav_zones_page.py
+++ b/Examples/nav_zones/nav_zones_page.py
@@ -1,0 +1,222 @@
+# Copyright 2023 BlueCat Networks (USA) Inc. and its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# By: BlueCat Networks
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
+# Description: Gateway workflow to demonstrate use of REST API v2 client.
+
+"""
+Navigate zones page
+"""
+from bluecat import route
+from bluecat.address_manager import BAMAPI
+from bluecat.gateway.decorators import api_exc_handler, page_exc_handler, require_permission
+from bluecat.util import no_cache
+from bluecat_libraries.address_manager.api import Client as V1Client
+from bluecat_libraries.address_manager.apiv2 import Client as V2Client
+from bluecat_libraries.address_manager.constants import ObjectType
+from dataclasses import dataclass
+from flask import g, jsonify, render_template, request
+from main_app import app
+
+
+@dataclass(init=True, frozen=True)
+class IdNamePair:
+    """Class for holding ID and name"""
+
+    id: int
+    name: str
+
+
+def items_to_pairs(data) -> list[IdNamePair]:
+    """
+    Convert the data into IdNamePair class object
+
+    :return: A list of IdNamePair Object
+    """
+    return [IdNamePair(id=o["id"], name=o["name"]) for o in data]
+
+
+# region BAM actions
+
+
+def _get_configurations_v1(client: V1Client) -> list[IdNamePair]:
+    """
+    Get configurations using REST v1 client
+
+    :return: A list of IdNamePair Object
+    """
+    data = client.get_entities(0, ObjectType.CONFIGURATION, 0, 9999)  # NOTE: Hard-coded count.
+    return items_to_pairs(data)
+
+
+def _get_configurations_v2(client: V2Client) -> list[IdNamePair]:
+    """
+    Get configurations using REST v2 client
+
+    :return: A list of IdNamePair Object
+    """
+    rdata = client.http_get(
+        "/configurations", params={"fields": "id,name", "orderBy": "desc(name)", "limit": "9999"}
+    )
+    data = rdata["data"]
+    return items_to_pairs(data)
+
+
+def get_configurations(bam_api: BAMAPI) -> list[IdNamePair]:
+    """
+    Get configurations based on which version of API is configured on Gateway
+
+    :return: A list of IdNamePair Object
+    """
+    return _get_configurations_v2(bam_api.v2) if bam_api.v2 else _get_configurations_v1(bam_api.v1)
+
+
+def _get_views_v1(client: V1Client, parent_id: int) -> list[IdNamePair]:
+    """
+    Get views using REST v1 client
+
+    :return: A list of IdNamePair Object
+    """
+    data = client.get_entities(parent_id, ObjectType.VIEW, 0, 9999)  # NOTE: Hard-coded count.
+    return items_to_pairs(data)
+
+
+def _get_views_v2(client: V2Client, parent_id: int) -> list[IdNamePair]:
+    """
+    Get views using REST v2 client
+
+    :return: A list of IdNamePair Object
+    """
+    rdata = client.http_get(
+        f"/configurations/{parent_id}/views",
+        params={"fields": "id,name", "orderBy": "desc(name)", "limit": "9999"},
+    )
+    data = rdata["data"]
+    return items_to_pairs(data)
+
+
+def get_views_in(bam_api: BAMAPI, parent_id: int) -> list[IdNamePair]:
+    """
+    Get views based on which version of API is configured on Gateway
+
+    :return: A list of IdNamePair Object
+    """
+    return (
+        _get_views_v2(bam_api.v2, parent_id) if bam_api.v2 else _get_views_v1(bam_api.v1, parent_id)
+    )
+
+
+def _get_zones_v1(client: V1Client, parent_id: int) -> list[IdNamePair]:
+    """
+    Get zones using REST v2 client
+
+    :return: A list of IdNamePair Object
+    """
+    data = client.get_entities(parent_id, ObjectType.ZONE, 0, 9999)  # NOTE: Hard-coded count.
+    return items_to_pairs(data)
+
+
+def _get_zones_v2(client: V2Client, parent_id: int) -> list[IdNamePair]:
+    """
+    Get zones using REST v2 client
+
+    :return: A list of IdNamePair Object
+    """
+    rdata = client.http_get(
+        f"/views/{parent_id}/zones",
+        params={"fields": "id,name", "orderBy": "desc(name)", "limit": "9999"},
+    )
+    data = rdata["data"]
+    return items_to_pairs(data)
+
+
+def get_zones_in(bam_api: BAMAPI, parent_id: int) -> list[IdNamePair]:
+    """
+    Get zones based on which version of API is configured on Gateway
+
+    :return: A list of IdNamePair Object
+    """
+    return (
+        _get_zones_v2(bam_api.v2, parent_id) if bam_api.v2 else _get_zones_v1(bam_api.v1, parent_id)
+    )
+
+
+# endregion BAM actions
+# region Page
+
+
+@route(app, "/nav_zones/", methods=["GET"])
+@no_cache
+@page_exc_handler
+@require_permission("nav_zones_page")
+def page():
+    """
+    Renders the page the user would see when selecting the workflow
+
+    :return:
+    """
+    return render_template("nav_zones.html")
+
+
+# endregion Page
+# region Data API
+
+
+@route(app, "/nav_zones/api/v1/configurations/", methods=["GET"])
+@no_cache
+@api_exc_handler
+@require_permission("nav_zones_page")
+def configurations():
+    """
+    Retrieves the configurations available in Address Manager
+
+    :return:
+    """
+    data = get_configurations(g.user.bam_api)
+    return jsonify(data)
+
+
+@route(app, "/nav_zones/api/v1/views/", methods=["GET"])
+@no_cache
+@api_exc_handler
+@require_permission("nav_zones_page")
+def views():
+    """
+    Retrieves the views available in Address Manager
+
+    :return:
+    """
+    parent_id = request.args["parent_id"]
+    data = get_views_in(g.user.bam_api, parent_id)
+    return jsonify(data)
+
+
+@route(app, "/nav_zones/api/v1/zones/", methods=["GET"])
+@no_cache
+@api_exc_handler
+@require_permission("nav_zones_page")
+def zones():
+    """
+    Retrieves the zones available in Address Manager
+
+    :return:
+    """
+    parent_id = request.args["parent_id"]
+    data = get_zones_in(g.user.bam_api, parent_id)
+    return jsonify(data)
+
+
+# endregion Data API

--- a/Examples/nav_zones/templates/nav_zones.html
+++ b/Examples/nav_zones/templates/nav_zones.html
@@ -1,4 +1,4 @@
-<!-- Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
+<!-- Copyright 2023 BlueCat Networks (USA) Inc. and its affiliates
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -15,29 +15,36 @@ limitations under the License.
 By: BlueCat Networks
 Date: 2023-04-05
 Gateway Version: 23.1.0
-Description: Example Gateway workflow
+Description: Gateway workflow to demonstrate use of REST API v2 client.
 -->
 
 {% extends "base.html" %}
 
 {% block css %}
-<link rel="stylesheet" href="css/update_ip4_address_page.css?version={{ g.version | urlencode }}">
+{#
+<link rel="stylesheet" href="css/nav_zones.css?version={{ g.version | urlencode }}">
+#}
 {% endblock %}
 
 {% block title %}
-{{ text['title'] }}
+Navigate zones
 {% endblock %}
 
 {% block heading %}
-{{ text['title'] }}
+Navigate zones
 {% endblock %}
 
 {% block custom %}
-    <p>{{ text['info'] }}</p>
-    {% from "form_helper.html" import render_form %}
-    {{ render_form(form, action=url_for('update_ip4_addressupdate_ip4_address_update_ip4_address_page_form'), id="update_ip_form") }}
+<form>
+    <label for="configurations">Configurations</label>
+    <select id="configurations" size="10"></select>
+    <label for="views">Views</label>
+    <select id="views" size="10"></select>
+    <label for="zones">Zones</label>
+    <select id="zones" size="10"></select>
+</form>
 {% endblock %}
 
 {% block scripts %}
-<script src="js/update_ip4_address_page.js?version={{ g.version | urlencode }}"></script>
+<script src="js/nav_zones.js?version={{ g.version | urlencode }}"></script>
 {% endblock %}

--- a/Examples/rest_endpoints/README.md
+++ b/Examples/rest_endpoints/README.md
@@ -1,9 +1,9 @@
 # **Example REST Workflows**
 ## Access Gateway through scripts
 
-**BlueCat Gateway Version:** 22.11.1 or greater <br/>
-**BAM version:** 9.2.0 or greater <br/>
+**BlueCat Gateway Version:** 23.1.0 or greater <br/>
+**BAM version:** 9.3.0 or greater <br/>
 **Dependencies:** None <br/>
 **Description/Example Usage:** The Rest example workflow creates non-UI based workflows. You can use this workflow if you want to access Gateway through scripts instead of the UI. This workflow is intended for customers that primary need automated workflows that will integrate with third-party systems and as such will call Gateway endpoints to execute rest workflows.
 
-©2020-2022 BlueCat Networks (USA) Inc. and its affiliates (collectively 'BlueCat'). All rights reserved.
+©2020-2023 BlueCat Networks (USA) Inc. and its affiliates (collectively 'BlueCat'). All rights reserved.

--- a/Examples/rest_endpoints/__init__.py
+++ b/Examples/rest_endpoints/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 # By: BlueCat Networks
-# Date: 2022-11-30
-# Gateway Version: 22.11.1
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
 # Description: Example Gateway workflow
 
 # pylint: disable=redefined-builtin,missing-docstring

--- a/Examples/rest_endpoints/rest_endpoints.py
+++ b/Examples/rest_endpoints/rest_endpoints.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 BlueCat Networks (USA) Inc. and its affiliates
+# Copyright 2020-2023 BlueCat Networks (USA) Inc. and its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 # By: BlueCat Networks
-# Date: 2022-11-30
-# Gateway Version: 22.11.1
+# Date: 2023-04-05
+# Gateway Version: 23.1.0
 # Description: Example Gateway workflow
 
 """


### PR DESCRIPTION
- Added new example workflow to demonstrate use of new client to BAM RESTful v2 API
- Removed from examples redundant calls to private method g.user.get_options()
- Updated Gateway version in examples
- Updated supported BAM version in examples 